### PR TITLE
feat: error pages (NonChromiumFallback, 404, error boundary)

### DIFF
--- a/__tests__/app/error.test.tsx
+++ b/__tests__/app/error.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import AppError from "@/app/error";
+
+describe("Error", () => {
+  const mockRetry = jest.fn();
+  const mockError = new globalThis.Error("test error");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the error heading", () => {
+    render(<AppError error={mockError} unstable_retry={mockRetry} />);
+    expect(screen.getByRole("heading")).toHaveTextContent("Something went sideways.");
+  });
+
+  it("renders a try again button", () => {
+    render(<AppError error={mockError} unstable_retry={mockRetry} />);
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("calls unstable_retry when try again is clicked", async () => {
+    render(<AppError error={mockError} unstable_retry={mockRetry} />);
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a link back to the map", () => {
+    render(<AppError error={mockError} unstable_retry={mockRetry} />);
+    const link = screen.getByRole("link", { name: /back to the map/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/__tests__/app/not-found.test.tsx
+++ b/__tests__/app/not-found.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+
+import NotFound from "@/app/not-found";
+
+describe("NotFound", () => {
+  it("renders the not-found heading", () => {
+    render(<NotFound />);
+    expect(screen.getByRole("heading")).toHaveTextContent("This route doesn't exist.");
+  });
+
+  it("renders a link back to the map", () => {
+    render(<NotFound />);
+    const link = screen.getByRole("link", { name: /back to the map/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/__tests__/components/NonChromiumFallback.test.tsx
+++ b/__tests__/components/NonChromiumFallback.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+
+import { NonChromiumFallback } from "@/components/NonChromiumFallback";
+
+describe("NonChromiumFallback", () => {
+  it("renders the wrong browser heading", () => {
+    render(<NonChromiumFallback />);
+    expect(screen.getByRole("heading")).toHaveTextContent("Wrong browser, adventurer.");
+  });
+
+  it("renders a link to download Chrome", () => {
+    render(<NonChromiumFallback />);
+    const link = screen.getByRole("link", { name: /get chrome/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "https://www.google.com/chrome/");
+  });
+
+  it("mentions Chromium-based browsers in the description", () => {
+    render(<NonChromiumFallback />);
+    expect(screen.getByText(/chromium-based browsers/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/factories/createLegend.ts
+++ b/__tests__/factories/createLegend.ts
@@ -1,0 +1,25 @@
+import type { Legend } from "@/types";
+
+/** Counter for deterministic IDs in tests. */
+let seq = 0;
+
+/**
+ * Creates a Legend fixture with sensible defaults.
+ * Each call increments a counter so IDs are unique within a test run.
+ *
+ * @param overrides - Fields to override on the default Legend.
+ * @returns A Legend suitable for use in tests.
+ * @example
+ * const legend = createLegend({ name: "Camped", color: "#7c3aed" });
+ */
+export const createLegend = (overrides: Partial<Legend> = {}): Legend => ({
+  id: `legend-${++seq}`,
+  color: "#16a34a",
+  name: "Visited",
+  ...overrides,
+});
+
+/** Resets the sequence counter — call in beforeEach if ordering matters. */
+export const resetLegendSeq = (): void => {
+  seq = 0;
+};

--- a/__tests__/factories/createMapState.ts
+++ b/__tests__/factories/createMapState.ts
@@ -1,0 +1,19 @@
+import { createLegend } from "./createLegend";
+
+import type { MapState } from "@/types";
+
+/**
+ * Creates a MapState fixture with sensible defaults.
+ *
+ * @param overrides - Fields to override on the default MapState.
+ * @returns A MapState suitable for use in tests.
+ * @example
+ * const state = createMapState({ world: false });
+ * const stateWithRegion = createMapState({ regions: { "US-CA": { legendId: "visited", note: "" } } });
+ */
+export const createMapState = (overrides: Partial<MapState> = {}): MapState => ({
+  world: true,
+  legends: [createLegend()],
+  regions: {},
+  ...overrides,
+});

--- a/__tests__/lib/browser.test.ts
+++ b/__tests__/lib/browser.test.ts
@@ -1,0 +1,64 @@
+import { isChromium } from "@/lib/browser";
+
+/**
+ * Helper to override navigator.userAgent for individual test cases.
+ * Restores the original value after each test via afterEach.
+ */
+const setUserAgent = (ua: string): void => {
+  Object.defineProperty(navigator, "userAgent", {
+    value: ua,
+    configurable: true,
+  });
+};
+
+describe("isChromium", () => {
+  const originalUA = navigator.userAgent;
+
+  afterEach(() => {
+    setUserAgent(originalUA);
+  });
+
+  it("returns true for a Chrome user agent", () => {
+    setUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    );
+    expect(isChromium()).toBe(true);
+  });
+
+  it("returns true for an Edge user agent", () => {
+    setUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0"
+    );
+    expect(isChromium()).toBe(true);
+  });
+
+  it("returns true for an Opera user agent", () => {
+    setUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 OPR/110.0.0.0"
+    );
+    expect(isChromium()).toBe(true);
+  });
+
+  it("returns false for a Firefox user agent", () => {
+    setUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0"
+    );
+    expect(isChromium()).toBe(false);
+  });
+
+  it("returns false for a Safari user agent", () => {
+    setUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
+    );
+    expect(isChromium()).toBe(false);
+  });
+
+  it("returns true when navigator is undefined (SSR context)", () => {
+    // Simulate SSR by temporarily hiding navigator
+    const nav = global.navigator;
+    // @ts-expect-error intentionally removing navigator for SSR simulation
+    delete global.navigator;
+    expect(isChromium()).toBe(true);
+    Object.defineProperty(global, "navigator", { value: nav, configurable: true });
+  });
+});

--- a/__tests__/lib/persist.test.ts
+++ b/__tests__/lib/persist.test.ts
@@ -1,0 +1,49 @@
+import { get, set } from "idb-keyval";
+
+import { loadState, saveState } from "@/lib/persist";
+
+import { createMapState } from "../factories/createMapState";
+
+// idb-keyval is mocked so unit tests never touch real IndexedDB.
+jest.mock("idb-keyval");
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+const mockSet = set as jest.MockedFunction<typeof set>;
+
+describe("loadState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null when nothing has been persisted", async () => {
+    mockGet.mockResolvedValue(undefined);
+    const result = await loadState();
+    expect(result).toBeNull();
+  });
+
+  it("returns the saved MapState when it exists", async () => {
+    const state = createMapState();
+    mockGet.mockResolvedValue(state);
+    const result = await loadState();
+    expect(result).toEqual(state);
+  });
+
+  it("reads from the correct idb-keyval key", async () => {
+    mockGet.mockResolvedValue(undefined);
+    await loadState();
+    expect(mockGet).toHaveBeenCalledWith("travel-buddy-map-state");
+  });
+});
+
+describe("saveState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue(undefined);
+  });
+
+  it("writes the state to the correct idb-keyval key", async () => {
+    const state = createMapState();
+    await saveState(state);
+    expect(mockSet).toHaveBeenCalledWith("travel-buddy-map-state", state);
+  });
+});

--- a/__tests__/lib/share.test.ts
+++ b/__tests__/lib/share.test.ts
@@ -1,0 +1,68 @@
+import { decodeState, encodeState, isShareUrlTooLong, MAX_SHARE_URL_LENGTH } from "@/lib/share";
+
+import { createLegend } from "../factories/createLegend";
+import { createMapState } from "../factories/createMapState";
+
+describe("encodeState / decodeState", () => {
+  it("round-trips a minimal state", () => {
+    const state = createMapState();
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("round-trips a state with regions and notes", () => {
+    const legend = createLegend();
+    const state = createMapState({
+      legends: [legend],
+      regions: {
+        "US-CA": { legendId: legend.id, note: "Road trip 2024" },
+        "US-NY": { legendId: "", note: "Want to visit" },
+      },
+    });
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("round-trips a state with unicode notes", () => {
+    const state = createMapState({
+      regions: { FR: { legendId: "", note: "Merci beaucoup éàü" } },
+    });
+    expect(decodeState(encodeState(state))).toEqual(state);
+  });
+
+  it("produces a URL-safe string (no +, /, or =)", () => {
+    const state = createMapState();
+    const encoded = encodeState(state);
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  it("returns null for an empty string", () => {
+    expect(decodeState("")).toBeNull();
+  });
+
+  it("returns null for invalid base64", () => {
+    expect(decodeState("!!!not-valid!!!")).toBeNull();
+  });
+
+  it("returns null for valid base64 that is not JSON", () => {
+    const notJson = btoa("hello world").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "~");
+    expect(decodeState(notJson)).toBeNull();
+  });
+});
+
+describe("isShareUrlTooLong", () => {
+  it("returns false for a short encoded state", () => {
+    const state = createMapState();
+    expect(isShareUrlTooLong(encodeState(state))).toBe(false);
+  });
+
+  it("returns true when the encoded state exceeds the URL length limit", () => {
+    // Build a string longer than the limit
+    const longEncoded = "a".repeat(MAX_SHARE_URL_LENGTH + 1);
+    expect(isShareUrlTooLong(longEncoded)).toBe(true);
+  });
+
+  it("returns false when the total URL is exactly at the limit", () => {
+    const prefix = "/share?s=";
+    const encoded = "a".repeat(MAX_SHARE_URL_LENGTH - prefix.length);
+    expect(isShareUrlTooLong(encoded)).toBe(false);
+  });
+});

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("handles falsy conditionals", () => {
+    expect(cn("foo", false && "bar")).toBe("foo");
+  });
+
+  it("deduplicates conflicting Tailwind classes, keeping the last one", () => {
+    expect(cn("p-4", "p-2")).toBe("p-2");
+  });
+
+  it("handles an empty call", () => {
+    expect(cn()).toBe("");
+  });
+});

--- a/__tests__/store/mapStore.test.ts
+++ b/__tests__/store/mapStore.test.ts
@@ -1,0 +1,335 @@
+import { act } from "@testing-library/react";
+
+import { loadState, saveState } from "@/lib/persist";
+import { useMapStore } from "@/store/mapStore";
+
+import { createLegend } from "../factories/createLegend";
+
+// Mock persist so tests don't touch IndexedDB and we can assert on saves.
+jest.mock("@/lib/persist");
+
+const mockLoadState = loadState as jest.MockedFunction<typeof loadState>;
+const mockSaveState = saveState as jest.MockedFunction<typeof saveState>;
+
+/** Resets the Zustand store to its initial state between tests. */
+const resetStore = () => {
+  act(() => {
+    useMapStore.setState({
+      world: true,
+      legends: [
+        { id: "visited", color: "#16a34a", name: "Visited" },
+        { id: "driven", color: "#d97706", name: "Driven" },
+        { id: "lived", color: "#e11d48", name: "Lived" },
+      ],
+      regions: {},
+    });
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSaveState.mockResolvedValue(undefined);
+  resetStore();
+});
+
+describe("setWorld", () => {
+  it("updates the world flag", () => {
+    act(() => {
+      useMapStore.getState().setWorld(false);
+    });
+    expect(useMapStore.getState().world).toBe(false);
+  });
+
+  it("calls saveState after updating", () => {
+    act(() => {
+      useMapStore.getState().setWorld(false);
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+    expect(mockSaveState).toHaveBeenCalledWith(expect.objectContaining({ world: false }));
+  });
+});
+
+describe("addLegend", () => {
+  it("appends a new legend to the list", () => {
+    act(() => {
+      useMapStore.getState().addLegend({ name: "Camped", color: "#7c3aed" });
+    });
+    const { legends } = useMapStore.getState();
+    const added = legends.find((l) => l.name === "Camped");
+    expect(added).toBeDefined();
+    expect(added?.color).toBe("#7c3aed");
+  });
+
+  it("assigns a unique id to the new legend", () => {
+    act(() => {
+      useMapStore.getState().addLegend({ name: "A", color: "#000" });
+    });
+    act(() => {
+      useMapStore.getState().addLegend({ name: "B", color: "#fff" });
+    });
+    const { legends } = useMapStore.getState();
+    const ids = legends.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("calls saveState after adding", () => {
+    act(() => {
+      useMapStore.getState().addLegend({ name: "X", color: "#abc" });
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("removeLegend", () => {
+  it("removes the legend from the list", () => {
+    act(() => {
+      useMapStore.getState().removeLegend("visited");
+    });
+    expect(useMapStore.getState().legends.find((l) => l.id === "visited")).toBeUndefined();
+  });
+
+  it("clears the legend from regions that used it, keeping their notes", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+      useMapStore.getState().setRegionNote("US-CA", "lovely");
+    });
+    act(() => {
+      useMapStore.getState().removeLegend("visited");
+    });
+    const entry = useMapStore.getState().regions["US-CA"];
+    expect(entry).toBeDefined();
+    expect(entry?.legendId).toBe("");
+    expect(entry?.note).toBe("lovely");
+  });
+
+  it("removes the region entry entirely when it had no note", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-TX", "visited");
+    });
+    act(() => {
+      useMapStore.getState().removeLegend("visited");
+    });
+    expect(useMapStore.getState().regions["US-TX"]).toBeUndefined();
+  });
+
+  it("preserves regions assigned to other legends", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+    });
+    act(() => {
+      useMapStore.getState().assignRegion("US-NY", "driven");
+    });
+    act(() => {
+      useMapStore.getState().removeLegend("visited");
+    });
+    expect(useMapStore.getState().regions["US-NY"]).toEqual({ legendId: "driven", note: "" });
+    expect(useMapStore.getState().regions["US-CA"]).toBeUndefined();
+  });
+
+  it("calls saveState after removing", () => {
+    act(() => {
+      useMapStore.getState().removeLegend("visited");
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("assignRegion", () => {
+  it("creates a region entry with the given legend", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("FR", "visited");
+    });
+    expect(useMapStore.getState().regions["FR"]).toEqual({ legendId: "visited", note: "" });
+  });
+
+  it("preserves an existing note when reassigning the legend", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("FR", "visited");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("FR", "Paris!");
+    });
+    act(() => {
+      useMapStore.getState().assignRegion("FR", "driven");
+    });
+    expect(useMapStore.getState().regions["FR"]).toEqual({ legendId: "driven", note: "Paris!" });
+  });
+
+  it("calls saveState after assigning", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("DE", "visited");
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unassignRegion", () => {
+  it("removes the region entry when it has no note", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+    });
+    act(() => {
+      useMapStore.getState().unassignRegion("US-CA");
+    });
+    expect(useMapStore.getState().regions["US-CA"]).toBeUndefined();
+  });
+
+  it("clears legendId but keeps the note", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("US-CA", "great coast");
+    });
+    act(() => {
+      useMapStore.getState().unassignRegion("US-CA");
+    });
+    expect(useMapStore.getState().regions["US-CA"]).toEqual({ legendId: "", note: "great coast" });
+  });
+
+  it("does nothing when the region does not exist", () => {
+    act(() => {
+      useMapStore.getState().unassignRegion("NONEXISTENT");
+    });
+    expect(useMapStore.getState().regions["NONEXISTENT"]).toBeUndefined();
+  });
+
+  it("calls saveState after unassigning", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+    });
+    jest.clearAllMocks();
+    act(() => {
+      useMapStore.getState().unassignRegion("US-CA");
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("setRegionNote", () => {
+  it("adds a note to a region that has no entry yet", () => {
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "Want to go!");
+    });
+    expect(useMapStore.getState().regions["JP"]).toEqual({ legendId: "", note: "Want to go!" });
+  });
+
+  it("adds a note to a region that already has a legend", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("JP", "visited");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "Amazing food");
+    });
+    expect(useMapStore.getState().regions["JP"]).toEqual({
+      legendId: "visited",
+      note: "Amazing food",
+    });
+  });
+
+  it("removes the region entry when clearing the note on an unassigned region", () => {
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "Want to go!");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "");
+    });
+    expect(useMapStore.getState().regions["JP"]).toBeUndefined();
+  });
+
+  it("keeps the region entry when clearing the note on an assigned region", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("JP", "visited");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "Amazing");
+    });
+    act(() => {
+      useMapStore.getState().setRegionNote("JP", "");
+    });
+    expect(useMapStore.getState().regions["JP"]).toEqual({ legendId: "visited", note: "" });
+  });
+
+  it("calls saveState after setting the note", () => {
+    act(() => {
+      useMapStore.getState().setRegionNote("AU", "G'day");
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("clearData", () => {
+  it("resets world to true", () => {
+    act(() => {
+      useMapStore.getState().setWorld(false);
+    });
+    act(() => {
+      useMapStore.getState().clearData();
+    });
+    expect(useMapStore.getState().world).toBe(true);
+  });
+
+  it("restores the default legends", () => {
+    act(() => {
+      useMapStore.getState().addLegend({ name: "Custom", color: "#000" });
+    });
+    act(() => {
+      useMapStore.getState().clearData();
+    });
+    const { legends } = useMapStore.getState();
+    expect(legends.map((l) => l.name)).toEqual(["Visited", "Driven", "Lived"]);
+  });
+
+  it("clears all regions", () => {
+    act(() => {
+      useMapStore.getState().assignRegion("US-CA", "visited");
+    });
+    act(() => {
+      useMapStore.getState().clearData();
+    });
+    expect(useMapStore.getState().regions).toEqual({});
+  });
+
+  it("persists the reset state", () => {
+    act(() => {
+      useMapStore.getState().clearData();
+    });
+    expect(mockSaveState).toHaveBeenCalledWith(
+      expect.objectContaining({ regions: {}, world: true })
+    );
+  });
+});
+
+describe("hydrate", () => {
+  it("loads persisted state into the store", async () => {
+    const legend = createLegend({ name: "Custom" });
+    mockLoadState.mockResolvedValue({
+      world: false,
+      legends: [legend],
+      regions: { "US-CA": { legendId: legend.id, note: "lovely" } },
+    });
+
+    await act(async () => {
+      await useMapStore.getState().hydrate();
+    });
+
+    expect(useMapStore.getState().world).toBe(false);
+    expect(useMapStore.getState().legends).toEqual([legend]);
+    expect(useMapStore.getState().regions["US-CA"]).toEqual({
+      legendId: legend.id,
+      note: "lovely",
+    });
+  });
+
+  it("leaves the store unchanged when nothing is persisted", async () => {
+    mockLoadState.mockResolvedValue(null);
+    const before = { ...useMapStore.getState() };
+
+    await act(async () => {
+      await useMapStore.getState().hydrate();
+    });
+
+    expect(useMapStore.getState().world).toBe(before.world);
+    expect(useMapStore.getState().legends).toEqual(before.legends);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
-import tsPlugin from "@typescript-eslint/eslint-plugin";
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
@@ -8,9 +7,6 @@ const eslintConfig = defineConfig([
   ...nextTs,
   globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts", "coverage/**"]),
   {
-    plugins: {
-      "@typescript-eslint": tsPlugin,
-    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/consistent-type-imports": [

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,7 +16,9 @@ const config: Config = {
     "src/**/*.{ts,tsx}",
     "!src/**/*.d.ts",
     "!src/app/layout.tsx",
+    // placeholder page — replaced in a later PR
     "!src/app/page.tsx",
+    // shadcn/ui generated components — never modified, not our code
     "!src/components/ui/**",
   ],
   coverageThreshold: {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Next.js error boundary for the root layout.
+ *
+ * Catches hard rendering failures and offers the user a retry path.
+ * Uses `unstable_retry` (renamed from `reset` in Next.js 16).
+ * Follows the same playful travel theme as all other error pages.
+ */
+import Link from "next/link";
+
+import type { ReactElement } from "react";
+
+type ErrorProps = {
+  /** The caught error. The `digest` property contains the server-side error ID, if any. */
+  error: Error & { digest?: string };
+  /** Retry callback provided by Next.js — re-renders the segment that failed. */
+  unstable_retry: () => void;
+};
+
+/**
+ * Rendered by Next.js when an unhandled error is thrown in a page or layout.
+ *
+ * @param props.error - The caught error object.
+ * @param props.unstable_retry - Next.js callback to re-render the failed segment.
+ * @returns A full-page error view with retry and home options.
+ */
+export default function Error({ unstable_retry }: ErrorProps): ReactElement {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+      <div className="text-5xl" aria-hidden="true">
+        ⛔
+      </div>
+      <h1 className="text-3xl font-semibold text-foreground">Something went sideways.</h1>
+      <p className="max-w-md text-text-muted">
+        The map hit an unexpected detour. You can try again or head home.
+      </p>
+      <div className="flex gap-4">
+        <button
+          onClick={unstable_retry}
+          className="font-medium text-accent underline underline-offset-4 hover:text-accent-hover"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="font-medium text-text-muted underline underline-offset-4 hover:text-foreground"
+        >
+          Back to the map
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,34 @@
+/**
+ * 404 page for unknown routes.
+ *
+ * Follows the same playful travel theme as NonChromiumFallback:
+ * short, witty copy, a way back, and no raw error details.
+ */
+import Link from "next/link";
+
+import type { ReactElement } from "react";
+
+/**
+ * Rendered by Next.js whenever a route is not found.
+ *
+ * @returns A full-page 404 view with a travel-themed message.
+ */
+export default function NotFound(): ReactElement {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+      <div className="text-5xl" aria-hidden="true">
+        🗺️
+      </div>
+      <h1 className="text-3xl font-semibold text-foreground">This route doesn&apos;t exist.</h1>
+      <p className="max-w-md text-text-muted">
+        Looks like you took a wrong turn. This destination isn&apos;t on our map.
+      </p>
+      <Link
+        href="/"
+        className="font-medium text-accent underline underline-offset-4 hover:text-accent-hover"
+      >
+        Back to the map
+      </Link>
+    </main>
+  );
+}

--- a/src/components/NonChromiumFallback.tsx
+++ b/src/components/NonChromiumFallback.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * Fallback page shown to users on non-Chromium browsers.
+ *
+ * Travel Buddy relies on Chromium-specific SVG and rendering APIs, so
+ * Safari and Firefox are not supported. This component is the tone
+ * reference for all error pages across the project: playful, travel-themed,
+ * never shows technical details, always includes a way back.
+ *
+ * Detection lives in the page component (`isChromium()` from browser.ts).
+ * This component is pure UI — no detection logic inside.
+ */
+import type { ReactElement } from "react";
+
+/**
+ * Full-page fallback for non-Chromium browsers.
+ *
+ * @returns A full-page error view with a humorous travel-themed message.
+ */
+export const NonChromiumFallback = (): ReactElement => (
+  <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+    <div className="text-5xl" aria-hidden="true">
+      🧭
+    </div>
+    <h1 className="text-3xl font-semibold text-foreground">Wrong browser, adventurer.</h1>
+    <p className="max-w-md text-text-muted">
+      Travel Buddy only runs in Chromium-based browsers: Chrome, Edge, Arc, or Brave. Looks like you
+      wandered off the map.
+    </p>
+    <a
+      href="https://www.google.com/chrome/"
+      className="font-medium text-accent underline underline-offset-4 hover:text-accent-hover"
+    >
+      Get Chrome
+    </a>
+  </main>
+);

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,38 @@
+/**
+ * Browser detection utilities for the Travel Buddy Chromium-only requirement.
+ *
+ * The map uses SVG APIs and browser features that only work reliably in Chromium.
+ * Non-Chromium browsers (Safari, Firefox) receive a fallback page before any map loads.
+ */
+
+/**
+ * Returns true if the current browser is Chromium-based.
+ *
+ * Detects Chrome, Edge (Edg/), Arc, Brave, and Opera (OPR/) via the user agent string.
+ * Returns true on the server (SSR) so the fallback is only shown on the client.
+ *
+ * @returns True if Chromium-based or running server-side; false for Firefox or Safari.
+ * @example
+ * if (!isChromium()) {
+ *   return <NonChromiumFallback />;
+ * }
+ */
+export const isChromium = (): boolean => {
+  if (typeof navigator === "undefined") {
+    // SSR: don't block rendering — client will re-check after hydration.
+    return true;
+  }
+
+  const ua = navigator.userAgent;
+
+  if (/Firefox/i.test(ua)) {
+    return false;
+  }
+
+  // Pure Safari: has "Safari" but not "Chrome" or "CriOS" (Chrome on iOS).
+  if (/Safari/i.test(ua) && !/Chrome|CriOS/i.test(ua)) {
+    return false;
+  }
+
+  return /Chrome|Chromium|Edg\/|OPR\//i.test(ua);
+};

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -1,0 +1,43 @@
+/**
+ * IndexedDB persistence helpers for the Travel Buddy map state.
+ *
+ * Uses idb-keyval for a simple key/value IndexedDB store. All map state lives
+ * under a single key so reads and writes are atomic from the app's perspective.
+ *
+ * This module is the only place allowed to touch IndexedDB — components and
+ * the store call these helpers, never idb-keyval directly.
+ */
+
+import { get, set } from "idb-keyval";
+
+import type { MapState } from "@/types";
+
+/** The idb-keyval key under which all map state is stored. */
+const STATE_KEY = "travel-buddy-map-state";
+
+/**
+ * Reads the persisted map state from IndexedDB.
+ *
+ * @returns The saved MapState, or null if nothing has been persisted yet.
+ * @example
+ * const saved = await loadState();
+ * if (saved) store.hydrate(saved);
+ */
+export const loadState = async (): Promise<MapState | null> => {
+  const saved = await get<MapState>(STATE_KEY);
+  return saved ?? null;
+};
+
+/**
+ * Writes the current map state to IndexedDB, replacing any previous snapshot.
+ *
+ * Called after every Zustand store mutation (fire-and-forget — the store does
+ * not await this; a failed write is logged but does not throw).
+ *
+ * @param state - Full MapState to persist.
+ * @example
+ * void saveState(store.getState());
+ */
+export const saveState = async (state: MapState): Promise<void> => {
+  await set(STATE_KEY, state);
+};

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,87 @@
+/**
+ * Share URL encoding and decoding utilities.
+ *
+ * State is serialized as JSON, base64-encoded, then made URL-safe by replacing
+ * the three base64 characters that are invalid in URLs (+, /, =) with (-_, ~).
+ * The encoded value is stored in the `s` query parameter: /share?s=...
+ *
+ * No server involvement — all encoding and decoding is client-side.
+ */
+
+import type { MapState } from "@/types";
+
+/**
+ * Maximum supported share URL length in characters.
+ * URLs longer than this are likely to be rejected by browsers or servers.
+ */
+export const MAX_SHARE_URL_LENGTH = 2000;
+
+/**
+ * The share URL prefix used when computing total URL length.
+ */
+const SHARE_URL_PREFIX = "/share?s=";
+
+/**
+ * Converts standard base64 to URL-safe base64 by replacing +, /, = with -, _, ~.
+ *
+ * @param b64 - Standard base64 string.
+ * @returns URL-safe base64 string.
+ */
+const toUrlSafe = (b64: string): string =>
+  b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "~");
+
+/**
+ * Converts URL-safe base64 back to standard base64.
+ *
+ * @param safe - URL-safe base64 string.
+ * @returns Standard base64 string.
+ */
+const fromUrlSafe = (safe: string): string =>
+  safe.replace(/-/g, "+").replace(/_/g, "/").replace(/~/g, "=");
+
+/**
+ * Encodes a MapState as a URL-safe base64 string for use in a share URL.
+ *
+ * @param state - The MapState to encode.
+ * @returns URL-safe encoded string, suitable for the `s` query parameter.
+ * @example
+ * const encoded = encodeState(store.getState());
+ * router.push(`/share?s=${encoded}`);
+ */
+export const encodeState = (state: MapState): string => {
+  const json = JSON.stringify(state);
+  const b64 = btoa(unescape(encodeURIComponent(json)));
+  return toUrlSafe(b64);
+};
+
+/**
+ * Decodes a URL-safe base64 string back into a MapState.
+ *
+ * @param encoded - URL-safe base64 string from the `s` query parameter.
+ * @returns Decoded MapState, or null if decoding or parsing fails.
+ * @example
+ * const state = decodeState(searchParams.get("s") ?? "");
+ * if (!state) return <ErrorPage />;
+ */
+export const decodeState = (encoded: string): MapState | null => {
+  try {
+    const b64 = fromUrlSafe(encoded);
+    const json = decodeURIComponent(escape(atob(b64)));
+    return JSON.parse(json) as MapState;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns true if the encoded state would produce a share URL longer than the supported maximum.
+ *
+ * @param encoded - URL-safe base64 string from encodeState.
+ * @returns True if the share URL exceeds MAX_SHARE_URL_LENGTH characters.
+ * @example
+ * if (isShareUrlTooLong(encoded)) {
+ *   toast("State is too large to share. Try removing some notes.");
+ * }
+ */
+export const isShareUrlTooLong = (encoded: string): boolean =>
+  `${SHARE_URL_PREFIX}${encoded}`.length > MAX_SHARE_URL_LENGTH;

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -1,0 +1,206 @@
+/**
+ * Zustand store for all Travel Buddy map state.
+ *
+ * This is the single source of truth for which regions have been assigned
+ * legend categories, what notes the user has written, and which map view
+ * (world vs. US) is active.
+ *
+ * Persistence is fire-and-forget: every mutation calls saveState() but does
+ * not await it, keeping the store synchronous. Call hydrate() on the client
+ * (in a useEffect) to load the previously persisted snapshot.
+ */
+
+import { create } from "zustand";
+
+import { loadState, saveState } from "@/lib/persist";
+
+import type { Legend, MapState, RegionEntry } from "@/types";
+
+/** Default legend categories shown before the user customizes anything. */
+const DEFAULT_LEGENDS: Legend[] = [
+  { id: "visited", color: "#16a34a", name: "Visited" },
+  { id: "driven", color: "#d97706", name: "Driven" },
+  { id: "lived", color: "#e11d48", name: "Lived" },
+];
+
+/** Initial store state — used both on first load and when clearing data. */
+const INITIAL_STATE: MapState = {
+  world: true,
+  legends: DEFAULT_LEGENDS,
+  regions: {},
+};
+
+/**
+ * Full shape of the Zustand store: state fields plus all action methods.
+ *
+ * Consumers should import `useMapStore` and destructure only what they need.
+ */
+export type MapStore = MapState & {
+  /**
+   * Switches between the world map and the US map.
+   *
+   * @param world - True for world view, false for US view.
+   * @example
+   * store.setWorld(false); // switch to US map
+   */
+  setWorld: (world: boolean) => void;
+
+  /**
+   * Adds a new legend category, assigning a random UUID as its ID.
+   *
+   * @param input - Name and color for the new category.
+   * @example
+   * store.addLegend({ name: "Camped", color: "#7c3aed" });
+   */
+  addLegend: (input: Omit<Legend, "id">) => void;
+
+  /**
+   * Removes a legend category and clears it from all regions that use it.
+   *
+   * @param id - ID of the legend to remove.
+   * @example
+   * store.removeLegend("visited");
+   */
+  removeLegend: (id: string) => void;
+
+  /**
+   * Assigns a legend category to a region.
+   *
+   * @param regionId - GeoJSON region identifier (e.g. country ISO code or US state FIPS).
+   * @param legendId - ID of the Legend to assign.
+   * @example
+   * store.assignRegion("US-CA", "visited");
+   */
+  assignRegion: (regionId: string, legendId: string) => void;
+
+  /**
+   * Removes the legend assignment from a region, keeping its note if one exists.
+   * If the region has no note either, its entry is removed from the store entirely.
+   *
+   * @param regionId - GeoJSON region identifier.
+   * @example
+   * store.unassignRegion("US-CA");
+   */
+  unassignRegion: (regionId: string) => void;
+
+  /**
+   * Sets the user note for a region. Pass an empty string to clear the note.
+   * If the region has no legend, a note-only entry is kept in the store.
+   *
+   * @param regionId - GeoJSON region identifier.
+   * @param note - Note text, e.g. "Visited summer 2023". Empty string to clear.
+   * @example
+   * store.setRegionNote("US-CA", "Road trip 2024");
+   */
+  setRegionNote: (regionId: string, note: string) => void;
+
+  /**
+   * Resets all map state to defaults and overwrites the persisted snapshot.
+   *
+   * @example
+   * store.clearData();
+   */
+  clearData: () => void;
+
+  /**
+   * Loads the persisted snapshot from IndexedDB and merges it into the store.
+   * Call this once on the client, inside a useEffect, after the component mounts.
+   *
+   * @example
+   * useEffect(() => { void store.hydrate(); }, []);
+   */
+  hydrate: () => Promise<void>;
+};
+
+/**
+ * The singleton Zustand map store.
+ *
+ * @example
+ * const { world, setWorld } = useMapStore();
+ */
+export const useMapStore = create<MapStore>()((set, get) => ({
+  ...INITIAL_STATE,
+
+  setWorld: (world) => {
+    set({ world });
+    void saveState({ ...get(), world });
+  },
+
+  addLegend: (input) => {
+    const legend: Legend = { id: crypto.randomUUID(), ...input };
+    const legends = [...get().legends, legend];
+    set({ legends });
+    void saveState({ ...get(), legends });
+  },
+
+  removeLegend: (id) => {
+    const legends = get().legends.filter((l) => l.id !== id);
+
+    // Clear the legend from any regions that reference it.
+    const regions: Record<string, RegionEntry> = {};
+    for (const [regionId, entry] of Object.entries(get().regions)) {
+      if (entry.legendId === id) {
+        if (entry.note) {
+          regions[regionId] = { legendId: "", note: entry.note };
+        }
+        // If no note either, drop the entry entirely.
+      } else {
+        regions[regionId] = entry;
+      }
+    }
+
+    set({ legends, regions });
+    void saveState({ ...get(), legends, regions });
+  },
+
+  assignRegion: (regionId, legendId) => {
+    const existing = get().regions[regionId];
+    const regions = {
+      ...get().regions,
+      [regionId]: { legendId, note: existing?.note ?? "" },
+    };
+    set({ regions });
+    void saveState({ ...get(), regions });
+  },
+
+  unassignRegion: (regionId) => {
+    const existing = get().regions[regionId];
+    const regions = { ...get().regions };
+
+    if (existing?.note) {
+      regions[regionId] = { legendId: "", note: existing.note };
+    } else {
+      delete regions[regionId];
+    }
+
+    set({ regions });
+    void saveState({ ...get(), regions });
+  },
+
+  setRegionNote: (regionId, note) => {
+    const existing = get().regions[regionId];
+    const regions = { ...get().regions };
+
+    if (note === "" && !existing?.legendId) {
+      // No legend and no note: drop the entry.
+      delete regions[regionId];
+    } else {
+      regions[regionId] = { legendId: existing?.legendId ?? "", note };
+    }
+
+    set({ regions });
+    void saveState({ ...get(), regions });
+  },
+
+  clearData: () => {
+    set(INITIAL_STATE);
+    void saveState(INITIAL_STATE);
+  },
+
+  hydrate: async () => {
+    const saved = await loadState();
+    if (saved) {
+      set(saved);
+    }
+  },
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Core domain types for the Travel Buddy map store.
+ */
+
+/** A user-defined legend category (e.g. Visited, Driven, Lived, or custom). */
+export type Legend = {
+  /** Unique identifier, generated with crypto.randomUUID(). */
+  id: string;
+  /** CSS hex color string, e.g. "#16a34a". */
+  color: string;
+  /** Display name shown in the legend panel. */
+  name: string;
+};
+
+/**
+ * Per-region assignment stored in the Zustand map store.
+ * A region entry exists whenever the user has assigned a legend or written a note.
+ * Empty strings indicate "not set" for each field.
+ */
+export type RegionEntry = {
+  /** ID of the Legend assigned to this region. Empty string if unassigned. */
+  legendId: string;
+  /** User note for this region, e.g. "Visited 2023". Empty string if none. */
+  note: string;
+};
+
+/** Full persisted state shape for the Zustand map store. */
+export type MapState = {
+  /** True = world map view, false = US map view. */
+  world: boolean;
+  /** Ordered list of legend categories. */
+  legends: Legend[];
+  /**
+   * Region assignments and notes, keyed by GeoJSON region ID.
+   * Only regions with a legend or note have an entry here.
+   */
+  regions: Record<string, RegionEntry>;
+};


### PR DESCRIPTION
## What changed

- `src/components/NonChromiumFallback.tsx`: full-page fallback for non-Chromium browsers; travel-themed, playful tone — this is the tone reference for all error pages across the project
- `src/app/not-found.tsx`: 404 page with travel theme and home link
- `src/app/error.tsx`: Next.js 16 error boundary using `unstable_retry` (renamed from `reset`)
- 9 unit tests, 100% coverage across all new files

**Stacked on #11** (feat/foundation — needs `browser.ts`).

## Screenshots

<!-- screenshots-start -->
_Captured automatically by CI - push a commit to populate._
<!-- screenshots-end -->