### PR TITLE
fix(readme): quote mermaid node label containing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Interactive map to track regions you've visited, driven through, or lived in. Bu
 
 ## Browser Compatibility
 
-**Chromium-based browsers only** (Chrome, Edge, Arc, Brave). Safari and Firefox are not supported — non-Chromium users see a friendly fallback page.
+**Chromium-based browsers only** (Chrome, Edge, Arc, Brave). Safari and Firefox are not supported; non-Chromium users see a friendly fallback page.
 
 ## Stack
 
@@ -30,7 +30,7 @@ graph LR
         Store --> IDB[(IndexedDB)]
     end
 
-    Store --> Share[/share/id/ route]
+    Store --> Share["/share/[id] route"]
     P --> Legend[Legend panel]
     Legend --> Store
 ```


### PR DESCRIPTION
## What changed

- Quote the \`/share/[id] route\` node label in the architecture diagram — Mermaid treats unquoted forward slashes as a lexical error
- Replace em dash with semicolon in browser compatibility note

## Screenshots

<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->