### PR TITLE
feat(ui): header, legend panel, dark mode, and zoom controls

### DIFF
--- a/__tests__/components/AddLegendModal.test.tsx
+++ b/__tests__/components/AddLegendModal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AddLegendModal } from "@/components/AddLegendModal";
+import { useMapStore } from "@/store/mapStore";
+
+jest.mock("@/store/mapStore");
+
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const setupStore = () => {
+  const addLegend = jest.fn();
+  mockUseMapStore.mockReturnValue({
+    addLegend,
+    legends: [],
+    regions: {},
+    world: true,
+    setWorld: jest.fn(),
+    removeLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn().mockResolvedValue(undefined),
+  } as ReturnType<typeof useMapStore>);
+  return { addLegend };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AddLegendModal", () => {
+  it("renders the trigger button", () => {
+    setupStore();
+    render(<AddLegendModal />);
+    expect(screen.getByRole("button", { name: /add category/i })).toBeInTheDocument();
+  });
+
+  it("dialog is not visible before the trigger is clicked", () => {
+    setupStore();
+    render(<AddLegendModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens the dialog when the trigger button is clicked", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /add legend category/i })).toBeInTheDocument();
+  });
+
+  it("renders the name input and color picker in the dialog", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/pick a color/i)).toBeInTheDocument();
+  });
+
+  it("Add button is disabled when name is empty", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    expect(screen.getByRole("button", { name: /^add$/i })).toBeDisabled();
+  });
+
+  it("Add button is enabled once a name is typed", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped");
+    expect(screen.getByRole("button", { name: /^add$/i })).not.toBeDisabled();
+  });
+
+  it("calls addLegend with trimmed name and selected color on save", async () => {
+    const { addLegend } = setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped");
+    await userEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    expect(addLegend).toHaveBeenCalledWith(expect.objectContaining({ name: "Camped" }));
+  });
+
+  it("closes the dialog after saving", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped");
+    await userEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not call addLegend when Cancel is clicked", async () => {
+    const { addLegend } = setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped");
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(addLegend).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("submits via Enter key when name is filled", async () => {
+    const { addLegend } = setupStore();
+    render(<AddLegendModal />);
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped{Enter}");
+    expect(addLegend).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets name field when dialog is closed via Cancel", async () => {
+    setupStore();
+    render(<AddLegendModal />);
+    // Open and type a name
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "Camped");
+    // Cancel
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    // Re-open
+    await userEvent.click(screen.getByRole("button", { name: /add category/i }));
+    expect(screen.getByLabelText(/name/i)).toHaveValue("");
+  });
+});

--- a/__tests__/components/AmericaMap.test.tsx
+++ b/__tests__/components/AmericaMap.test.tsx
@@ -23,6 +23,9 @@ jest.mock("react-simple-maps", () => {
     ComposableMap: ({ children }: { children: ReactNode }) => (
       <div data-testid="composable-map">{children}</div>
     ),
+    ZoomableGroup: ({ children }: { children: ReactNode }) => (
+      <div data-testid="zoomable-group">{children}</div>
+    ),
     Geographies: ({ children }: { children: (args: { geographies: MockGeo[] }) => ReactNode }) => (
       <div data-testid="geographies">{children({ geographies: mockGeos })}</div>
     ),
@@ -102,7 +105,7 @@ describe("AmericaMap", () => {
     expect(screen.getByRole("heading", { name: "Texas" })).toBeInTheDocument();
   });
 
-  it("opens a region dialog when Enter is pressed on a state", async () => {
+  it("opens a region dialog when Enter is pressed on a state", () => {
     render(<AmericaMap />);
     // Use fireEvent.keyDown to bypass the button's Enter→click conversion,
     // ensuring the onKeyDown handler in AmericaMap is actually called.
@@ -112,7 +115,7 @@ describe("AmericaMap", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
-  it("opens a region dialog when Space is pressed on a state", async () => {
+  it("opens a region dialog when Space is pressed on a state", () => {
     render(<AmericaMap />);
     fireEvent.keyDown(screen.getByRole("button", { name: "California" }), {
       key: " ",
@@ -147,5 +150,20 @@ describe("AmericaMap", () => {
   it("renders the map in a container with the screenshot data attribute", () => {
     render(<AmericaMap />);
     expect(document.querySelector("[data-screenshot='us-map']")).toBeInTheDocument();
+  });
+
+  it("renders zoom control buttons", () => {
+    render(<AmericaMap />);
+    expect(screen.getByRole("button", { name: /zoom in/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /zoom out/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset zoom/i })).toBeInTheDocument();
+  });
+
+  it("zoom controls are interactive", async () => {
+    render(<AmericaMap />);
+    await userEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    await userEvent.click(screen.getByRole("button", { name: /zoom out/i }));
+    await userEvent.click(screen.getByRole("button", { name: /reset zoom/i }));
+    expect(screen.getByTestId("geo-06")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/AmericaMap.test.tsx
+++ b/__tests__/components/AmericaMap.test.tsx
@@ -131,11 +131,11 @@ describe("AmericaMap", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("closes the dialog when onClose is called", async () => {
+  it("closes the popover when the close button is clicked", async () => {
     render(<AmericaMap />);
     await userEvent.click(screen.getByRole("button", { name: "California" }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 

--- a/__tests__/components/AppShell.test.tsx
+++ b/__tests__/components/AppShell.test.tsx
@@ -7,6 +7,12 @@ jest.mock("@/lib/browser");
 jest.mock("@/components/MapContainer", () => ({
   MapContainer: () => <div data-testid="map-container" />,
 }));
+jest.mock("@/components/Header", () => ({
+  Header: () => <div data-testid="header" />,
+}));
+jest.mock("@/components/LegendPanel", () => ({
+  LegendPanel: () => <div data-testid="legend-panel" />,
+}));
 
 const mockIsChromium = isChromium as jest.MockedFunction<typeof isChromium>;
 
@@ -15,10 +21,12 @@ beforeEach(() => {
 });
 
 describe("AppShell", () => {
-  it("shows the map container for Chromium browsers", async () => {
+  it("shows the full app layout for Chromium browsers", async () => {
     mockIsChromium.mockReturnValue(true);
     render(<AppShell />);
     await waitFor(() => {
+      expect(screen.getByTestId("header")).toBeInTheDocument();
+      expect(screen.getByTestId("legend-panel")).toBeInTheDocument();
       expect(screen.getByTestId("map-container")).toBeInTheDocument();
     });
   });
@@ -34,10 +42,8 @@ describe("AppShell", () => {
   it("does not render user-visible content before the browser check resolves", () => {
     mockIsChromium.mockReturnValue(true);
     const { container } = render(<AppShell />);
-    // After effects flush, the map container should appear, not visible content
-    // from the placeholder. The placeholder is aria-hidden.
+    // Either the placeholder (pre-effect) or the app layout (post-effect) is present.
     const ariaHidden = container.querySelector("[aria-hidden='true']");
-    // Either the placeholder (pre-effect) or the map (post-effect) is present.
     const mapContainer = container.querySelector("[data-testid='map-container']");
     expect(ariaHidden !== null || mapContainer !== null).toBe(true);
   });

--- a/__tests__/components/DarkModeToggle.test.tsx
+++ b/__tests__/components/DarkModeToggle.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useTheme } from "next-themes";
+
+import { DarkModeToggle } from "@/components/DarkModeToggle";
+
+jest.mock("next-themes", () => ({
+  useTheme: jest.fn(),
+}));
+
+const mockUseTheme = useTheme as jest.MockedFunction<typeof useTheme>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("DarkModeToggle", () => {
+  it("shows 'switch to dark mode' label when theme is light", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: jest.fn(),
+      theme: "light",
+      themes: [],
+      systemTheme: undefined,
+      forcedTheme: undefined,
+    });
+    render(<DarkModeToggle />);
+    expect(screen.getByRole("button", { name: /switch to dark mode/i })).toBeInTheDocument();
+  });
+
+  it("shows 'switch to light mode' label when theme is dark", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: jest.fn(),
+      theme: "dark",
+      themes: [],
+      systemTheme: undefined,
+      forcedTheme: undefined,
+    });
+    render(<DarkModeToggle />);
+    expect(screen.getByRole("button", { name: /switch to light mode/i })).toBeInTheDocument();
+  });
+
+  it("calls setTheme with 'dark' when toggled from light", async () => {
+    const setTheme = jest.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme,
+      theme: "light",
+      themes: [],
+      systemTheme: undefined,
+      forcedTheme: undefined,
+    });
+    render(<DarkModeToggle />);
+    await userEvent.click(screen.getByRole("button", { name: /switch to dark mode/i }));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme with 'light' when toggled from dark", async () => {
+    const setTheme = jest.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme,
+      theme: "dark",
+      themes: [],
+      systemTheme: undefined,
+      forcedTheme: undefined,
+    });
+    render(<DarkModeToggle />);
+    await userEvent.click(screen.getByRole("button", { name: /switch to light mode/i }));
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("treats an unresolved theme as light (pre-hydration default)", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: undefined,
+      setTheme: jest.fn(),
+      theme: undefined,
+      themes: [],
+      systemTheme: undefined,
+      forcedTheme: undefined,
+    });
+    render(<DarkModeToggle />);
+    // Unresolved resolvedTheme is not "dark", so the label should show dark mode
+    expect(screen.getByRole("button", { name: /switch to dark mode/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Header } from "@/components/Header";
+import { useMapStore } from "@/store/mapStore";
+
+jest.mock("@/store/mapStore");
+jest.mock("next-themes", () => ({
+  useTheme: jest.fn().mockReturnValue({
+    resolvedTheme: "light",
+    setTheme: jest.fn(),
+    theme: "light",
+    themes: [],
+    systemTheme: undefined,
+    forcedTheme: undefined,
+  }),
+}));
+
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const setupStore = (world = true) => {
+  const setWorld = jest.fn();
+  mockUseMapStore.mockReturnValue({
+    world,
+    setWorld,
+    legends: [],
+    regions: {},
+    addLegend: jest.fn(),
+    removeLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn().mockResolvedValue(undefined),
+  } as ReturnType<typeof useMapStore>);
+  return { setWorld };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Header", () => {
+  it("renders the app title", () => {
+    setupStore();
+    render(<Header />);
+    expect(screen.getByText("Travel Buddy")).toBeInTheDocument();
+  });
+
+  it("renders World and United States toggle buttons", () => {
+    setupStore();
+    render(<Header />);
+    expect(screen.getByRole("button", { name: /world/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /united states/i })).toBeInTheDocument();
+  });
+
+  it("marks World button as pressed when world is true", () => {
+    setupStore(true);
+    render(<Header />);
+    expect(screen.getByRole("button", { name: /world/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /united states/i })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("marks United States button as pressed when world is false", () => {
+    setupStore(false);
+    render(<Header />);
+    expect(screen.getByRole("button", { name: /world/i })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: /united states/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("calls setWorld(true) when the World button is clicked", async () => {
+    const { setWorld } = setupStore(false);
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /world/i }));
+    expect(setWorld).toHaveBeenCalledWith(true);
+  });
+
+  it("calls setWorld(false) when the United States button is clicked", async () => {
+    const { setWorld } = setupStore(true);
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /united states/i }));
+    expect(setWorld).toHaveBeenCalledWith(false);
+  });
+
+  it("renders the dark mode toggle", () => {
+    setupStore();
+    render(<Header />);
+    expect(screen.getByRole("button", { name: /switch to dark mode/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/LegendPanel.test.tsx
+++ b/__tests__/components/LegendPanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LegendPanel } from "@/components/LegendPanel";
+import { useMapStore } from "@/store/mapStore";
+
+import { createLegend } from "../factories/createLegend";
+
+jest.mock("@/store/mapStore");
+// Stub out AddLegendModal to keep LegendPanel tests focused on the panel itself.
+jest.mock("@/components/AddLegendModal", () => ({
+  AddLegendModal: () => <button>Add category</button>,
+}));
+
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const setupStore = (
+  legends = [
+    createLegend({ id: "visited", name: "Visited", color: "#16a34a" }),
+    createLegend({ id: "driven", name: "Driven", color: "#d97706" }),
+  ]
+) => {
+  const removeLegend = jest.fn();
+  mockUseMapStore.mockReturnValue({
+    legends,
+    removeLegend,
+    regions: {},
+    world: true,
+    setWorld: jest.fn(),
+    addLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn().mockResolvedValue(undefined),
+  } as ReturnType<typeof useMapStore>);
+  return { removeLegend };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LegendPanel", () => {
+  it("renders a legend heading", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByRole("heading", { name: /legend/i })).toBeInTheDocument();
+  });
+
+  it("renders all legend category names", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByText("Visited")).toBeInTheDocument();
+    expect(screen.getByText("Driven")).toBeInTheDocument();
+  });
+
+  it("renders a remove button for each legend", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByRole("button", { name: /remove visited/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /remove driven/i })).toBeInTheDocument();
+  });
+
+  it("calls removeLegend with the correct id when a remove button is clicked", async () => {
+    const { removeLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /remove visited/i }));
+    expect(removeLegend).toHaveBeenCalledWith("visited");
+  });
+
+  it("renders an empty list gracefully when there are no legends", () => {
+    setupStore([]);
+    render(<LegendPanel />);
+    expect(screen.getByRole("heading", { name: /legend/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the add category trigger", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByRole("button", { name: /add category/i })).toBeInTheDocument();
+  });
+
+  it("renders the panel with the screenshot data attribute", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(document.querySelector("[data-screenshot='legend-panel']")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/RegionPopover.test.tsx
+++ b/__tests__/components/RegionPopover.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RegionPopover } from "@/components/RegionPopover";
+import { useMapStore } from "@/store/mapStore";
+
+import { createLegend } from "../factories/createLegend";
+
+jest.mock("@/store/mapStore");
+
+const mockAssignRegion = jest.fn();
+const mockUnassignRegion = jest.fn();
+const mockSetRegionNote = jest.fn();
+const mockOnClose = jest.fn();
+
+const setupStore = (
+  regionNote = "",
+  regionLegendId = "",
+  legends = [createLegend({ id: "visited", name: "Visited", color: "#16a34a" })]
+) => {
+  (useMapStore as jest.MockedFunction<typeof useMapStore>).mockReturnValue({
+    legends,
+    regions:
+      regionLegendId || regionNote
+        ? { "US-CA": { legendId: regionLegendId, note: regionNote } }
+        : {},
+    assignRegion: mockAssignRegion,
+    unassignRegion: mockUnassignRegion,
+    setRegionNote: mockSetRegionNote,
+  } as ReturnType<typeof useMapStore>);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupStore();
+});
+
+describe("RegionPopover", () => {
+  it("renders the region name as a heading", () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(screen.getByRole("heading", { name: "California" })).toBeInTheDocument();
+  });
+
+  it("renders with dialog role for accessibility", () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(screen.getByRole("dialog", { name: "California" })).toBeInTheDocument();
+  });
+
+  it("shows the existing note in the textarea", () => {
+    setupStore("Road trip 2024", "visited");
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(screen.getByRole("textbox", { name: /note for california/i })).toHaveValue(
+      "Road trip 2024"
+    );
+  });
+
+  it("calls setRegionNote and onClose when Save is clicked", async () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /note for california/i }),
+      "Great state"
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(mockSetRegionNote).toHaveBeenCalledWith("US-CA", "Great state");
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose without saving when the close button is clicked", async () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(mockSetRegionNote).not.toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a select trigger accessible to keyboard users", () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(
+      screen.getByRole("combobox", { name: /assign legend to california/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls assignRegion when a legend is selected from the dropdown", async () => {
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    await userEvent.click(screen.getByRole("combobox", { name: /assign legend to california/i }));
+    const visitedOption = await screen.findByRole("option", { name: /visited/i });
+    await userEvent.click(visitedOption);
+    expect(mockAssignRegion).toHaveBeenCalledWith("US-CA", "visited");
+  });
+
+  it("calls unassignRegion when None is selected", async () => {
+    setupStore("", "visited");
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    await userEvent.click(screen.getByRole("combobox", { name: /assign legend to california/i }));
+    const noneOption = await screen.findByRole("option", { name: /^none$/i });
+    await userEvent.click(noneOption);
+    expect(mockUnassignRegion).toHaveBeenCalledWith("US-CA");
+  });
+
+  it("initializes note from the store on mount", () => {
+    setupStore("Road trip 2024", "visited");
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(screen.getByRole("textbox", { name: /note for california/i })).toHaveValue(
+      "Road trip 2024"
+    );
+  });
+
+  it("shows legend name in the trigger when a legend is assigned (not the raw ID)", () => {
+    setupStore("", "visited");
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    // The trigger should display "Visited", not the raw legend ID.
+    expect(
+      screen.getByRole("combobox", { name: /assign legend to california/i })
+    ).toHaveTextContent("Visited");
+  });
+
+  it("shows legend name for a UUID legend ID (regression test for raw-ID display bug)", () => {
+    const uuid = "9c0e9e3d-87e0-4d30-9e77-fecffe775625";
+    setupStore("", uuid, [createLegend({ id: uuid, name: "Roadtrip", color: "#7c3aed" })]);
+    render(<RegionPopover regionId="US-CA" regionName="California" onClose={mockOnClose} />);
+    expect(
+      screen.getByRole("combobox", { name: /assign legend to california/i })
+    ).toHaveTextContent("Roadtrip");
+  });
+});

--- a/__tests__/components/WorldMap.test.tsx
+++ b/__tests__/components/WorldMap.test.tsx
@@ -148,4 +148,21 @@ describe("WorldMap", () => {
     render(<WorldMap />);
     expect(document.querySelector("[data-screenshot='world-map']")).toBeInTheDocument();
   });
+
+  it("renders zoom control buttons", () => {
+    render(<WorldMap />);
+    expect(screen.getByRole("button", { name: /zoom in/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /zoom out/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset zoom/i })).toBeInTheDocument();
+  });
+
+  it("zoom controls are interactive", async () => {
+    render(<WorldMap />);
+    // Clicking zoom controls should not throw
+    await userEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    await userEvent.click(screen.getByRole("button", { name: /zoom out/i }));
+    await userEvent.click(screen.getByRole("button", { name: /reset zoom/i }));
+    // Map is still rendered after zoom changes
+    expect(screen.getByTestId("geo-840")).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/WorldMap.test.tsx
+++ b/__tests__/components/WorldMap.test.tsx
@@ -129,11 +129,11 @@ describe("WorldMap", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("closes the dialog when onClose is called", async () => {
+  it("closes the popover when the close button is clicked", async () => {
     render(<WorldMap />);
     await userEvent.click(screen.getByRole("button", { name: "United States" }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 

--- a/__tests__/components/ZoomControls.test.tsx
+++ b/__tests__/components/ZoomControls.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ZoomControls } from "@/components/ZoomControls";
+
+describe("ZoomControls", () => {
+  it("renders zoom in, zoom out, and reset buttons", () => {
+    render(<ZoomControls onZoomIn={jest.fn()} onZoomOut={jest.fn()} onReset={jest.fn()} />);
+    expect(screen.getByRole("button", { name: /zoom in/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /zoom out/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset zoom/i })).toBeInTheDocument();
+  });
+
+  it("calls onZoomIn when the zoom in button is clicked", async () => {
+    const onZoomIn = jest.fn();
+    render(<ZoomControls onZoomIn={onZoomIn} onZoomOut={jest.fn()} onReset={jest.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    expect(onZoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onZoomOut when the zoom out button is clicked", async () => {
+    const onZoomOut = jest.fn();
+    render(<ZoomControls onZoomIn={jest.fn()} onZoomOut={onZoomOut} onReset={jest.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /zoom out/i }));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onReset when the reset button is clicked", async () => {
+    const onReset = jest.fn();
+    render(<ZoomControls onZoomIn={jest.fn()} onZoomOut={jest.fn()} onReset={onReset} />);
+    await userEvent.click(screen.getByRole("button", { name: /reset zoom/i }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
   /* Fonts */
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
+  --font-heading: var(--font-heading);
 
   /* Palette tokens */
   --color-background: var(--background);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Fraunces, Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
 
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 
 import "./globals.css";
 
@@ -14,23 +16,34 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
 });
 
+const fraunces = Fraunces({
+  variable: "--font-heading",
+  subsets: ["latin"],
+});
+
 export const metadata: Metadata = {
   title: "Travel Buddy",
   description: "Track the regions you've visited, driven through, and lived in.",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+/**
+ * Root layout wrapping all pages with fonts, theme provider, and base styles.
+ *
+ * @param children - Page content rendered inside the layout.
+ * @returns The HTML shell with ThemeProvider and font variables applied.
+ */
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${fraunces.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="h-full">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/AddLegendModal.tsx
+++ b/src/components/AddLegendModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * Modal dialog for adding a new legend category.
+ */
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/** Default color for new legend categories. */
+const DEFAULT_COLOR = "#16a34a";
+
+/**
+ * A button that opens a dialog for creating a new legend category.
+ *
+ * The dialog collects a name and color from the user and calls `addLegend`
+ * on the Zustand store. State is reset on close so the form is fresh each
+ * time it opens. The Add button is disabled until the name field is non-empty.
+ *
+ * @returns A trigger button + dialog for adding a legend category.
+ */
+export const AddLegendModal = (): ReactElement => {
+  const { addLegend } = useMapStore();
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(DEFAULT_COLOR);
+
+  const handleSave = () => {
+    if (name.trim()) {
+      addLegend({ name: name.trim(), color });
+      setName("");
+      setColor(DEFAULT_COLOR);
+      setIsOpen(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setName("");
+      setColor(DEFAULT_COLOR);
+    }
+    setIsOpen(open);
+  };
+
+  return (
+    <>
+      <Button
+        size="sm"
+        className="w-full"
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      >
+        <Plus className="h-4 w-4" />
+        Add category
+      </Button>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add legend category</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 py-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="legend-name">Name</Label>
+              <Input
+                id="legend-name"
+                placeholder="e.g. Camped, Roadtripped..."
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && name.trim()) {
+                    handleSave();
+                  }
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="legend-color">Color</Label>
+              <input
+                id="legend-color"
+                type="color"
+                value={color}
+                onChange={(e) => {
+                  setColor(e.target.value);
+                }}
+                className="h-9 w-full cursor-pointer rounded-md border border-input bg-background"
+                aria-label="Pick a color"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                handleOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={!name.trim()}>
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -7,7 +7,7 @@
 import { useState } from "react";
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
 
-import { RegionDialog } from "@/components/RegionDialog";
+import { RegionPopover } from "@/components/RegionPopover";
 import { ZoomControls } from "@/components/ZoomControls";
 import { useMapStore } from "@/store/mapStore";
 
@@ -154,11 +154,10 @@ export const AmericaMap = (): ReactElement => {
         <ZoomControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} onReset={handleReset} />
       </div>
       {selected && (
-        <RegionDialog
+        <RegionPopover
           key={selected.id}
           regionId={selected.id}
           regionName={selected.name}
-          isOpen={true}
           onClose={() => {
             setSelected(null);
           }}

--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -5,9 +5,10 @@
  */
 
 import { useState } from "react";
-import { ComposableMap, Geographies, Geography } from "react-simple-maps";
+import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
 
 import { RegionDialog } from "@/components/RegionDialog";
+import { ZoomControls } from "@/components/ZoomControls";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
@@ -22,6 +23,9 @@ const HOVER_FILL = "#b8b2ab";
 
 /** The stroke color between states. */
 const STROKE_COLOR = "#a09890";
+
+/** Maximum zoom level for the US map. */
+const MAX_ZOOM = 8;
 
 /** A region selected by the user, awaiting dialog interaction. */
 type SelectedRegion = {
@@ -47,76 +51,107 @@ const selectRegion = (id: string, name: string, setSelected: (r: SelectedRegion)
  *
  * Each state is colored by its assigned legend category. Clicking or pressing
  * Enter/Space on a state opens a RegionDialog for legend assignment and note
- * editing. The Albers USA projection repositions Alaska and Hawaii insets.
+ * editing. Supports pan and zoom via ZoomableGroup (both mouse/touch and the
+ * ZoomControls overlay buttons).
+ *
+ * The Albers USA projection repositions Alaska and Hawaii as insets. Center
+ * is tracked for controlled zoom so programmatic zoom-in stays anchored to
+ * the current view position.
  *
  * The GeoJSON is fetched lazily from /us.json (served from public/).
  *
- * @returns An interactive SVG US map with a region dialog overlay.
+ * @returns An interactive SVG US map with a region dialog overlay and zoom controls.
  */
 export const AmericaMap = (): ReactElement => {
   const { legends, regions } = useMapStore();
   const [selected, setSelected] = useState<SelectedRegion | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [center, setCenter] = useState<[number, number]>([0, 0]);
 
   const legendColors = Object.fromEntries(legends.map((l) => [l.id, l.color]));
 
+  const handleZoomIn = () => {
+    setZoom((z) => Math.min(z * 1.5, MAX_ZOOM));
+  };
+
+  const handleZoomOut = () => {
+    setZoom((z) => Math.max(z / 1.5, 1));
+  };
+
+  const handleReset = () => {
+    setZoom(1);
+    setCenter([0, 0]);
+  };
+
   return (
     <>
-      <div className="h-full w-full" data-screenshot="us-map">
+      <div className="relative h-full w-full" data-screenshot="us-map">
         <ComposableMap
           projection="geoAlbersUsa"
           projectionConfig={{ scale: 900 }}
           style={{ width: "100%", height: "100%" }}
         >
-          <Geographies geography={GEO_URL}>
-            {({ geographies }) =>
-              geographies.map((geo) => {
-                const regionId = String(geo.id);
-                const entry = regions[regionId];
-                const assignedColor = entry?.legendId
-                  ? (legendColors[entry.legendId] ?? DEFAULT_FILL)
-                  : DEFAULT_FILL;
-                const name = geo.properties["name"] as string;
-                const ariaLabel = entry?.legendId ? `${name} (assigned)` : name;
+          <ZoomableGroup
+            zoom={zoom}
+            center={center}
+            maxZoom={MAX_ZOOM}
+            onMoveEnd={({ coordinates, zoom: newZoom }) => {
+              setCenter(coordinates);
+              setZoom(newZoom);
+            }}
+          >
+            <Geographies geography={GEO_URL}>
+              {({ geographies }) =>
+                geographies.map((geo) => {
+                  const regionId = String(geo.id);
+                  const entry = regions[regionId];
+                  const assignedColor = entry?.legendId
+                    ? (legendColors[entry.legendId] ?? DEFAULT_FILL)
+                    : DEFAULT_FILL;
+                  const name = geo.properties["name"] as string;
+                  const ariaLabel = entry?.legendId ? `${name} (assigned)` : name;
 
-                return (
-                  <Geography
-                    key={geo.rsmKey}
-                    geography={geo}
-                    tabIndex={0}
-                    aria-label={ariaLabel}
-                    onClick={() => {
-                      selectRegion(regionId, name, setSelected);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
+                  return (
+                    <Geography
+                      key={geo.rsmKey}
+                      geography={geo}
+                      tabIndex={0}
+                      aria-label={ariaLabel}
+                      onClick={() => {
                         selectRegion(regionId, name, setSelected);
-                      }
-                    }}
-                    style={{
-                      default: {
-                        fill: assignedColor,
-                        outline: "none",
-                        stroke: STROKE_COLOR,
-                        strokeWidth: 0.5,
-                      },
-                      hover: {
-                        fill: entry?.legendId ? assignedColor : HOVER_FILL,
-                        outline: "none",
-                        stroke: STROKE_COLOR,
-                        strokeWidth: 0.5,
-                        cursor: "pointer",
-                      },
-                      pressed: {
-                        fill: assignedColor,
-                        outline: "none",
-                      },
-                    }}
-                  />
-                );
-              })
-            }
-          </Geographies>
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          selectRegion(regionId, name, setSelected);
+                        }
+                      }}
+                      style={{
+                        default: {
+                          fill: assignedColor,
+                          outline: "none",
+                          stroke: STROKE_COLOR,
+                          strokeWidth: 0.5,
+                        },
+                        hover: {
+                          fill: entry?.legendId ? assignedColor : HOVER_FILL,
+                          outline: "none",
+                          stroke: STROKE_COLOR,
+                          strokeWidth: 0.5,
+                          cursor: "pointer",
+                        },
+                        pressed: {
+                          fill: assignedColor,
+                          outline: "none",
+                        },
+                      }}
+                    />
+                  );
+                })
+              }
+            </Geographies>
+          </ZoomableGroup>
         </ComposableMap>
+        <ZoomControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} onReset={handleReset} />
       </div>
       {selected && (
         <RegionDialog

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 /**
- * Root client component: Chromium gate before rendering the map.
+ * Root client component: Chromium gate + full app layout.
  */
 
 import { useEffect, useState } from "react";
 
+import { Header } from "@/components/Header";
+import { LegendPanel } from "@/components/LegendPanel";
 import { MapContainer } from "@/components/MapContainer";
 import { NonChromiumFallback } from "@/components/NonChromiumFallback";
 import { isChromium } from "@/lib/browser";
@@ -20,9 +22,10 @@ import type { ReactElement } from "react";
  * ensures the initial render is always consistent.
  *
  * Renders nothing visible (a transparent placeholder) until the browser check
- * completes, then shows either the map or the NonChromiumFallback page.
+ * completes, then shows either the full app layout (header + legend + map) or
+ * the NonChromiumFallback page.
  *
- * @returns MapContainer for Chromium browsers; NonChromiumFallback otherwise.
+ * @returns The full app layout for Chromium browsers; NonChromiumFallback otherwise.
  */
 export const AppShell = (): ReactElement => {
   const [isChromiumBrowser, setIsChromiumBrowser] = useState<boolean | null>(null);
@@ -35,12 +38,22 @@ export const AppShell = (): ReactElement => {
   }, []);
 
   if (isChromiumBrowser === null) {
-    return <div className="min-h-screen bg-background" aria-hidden="true" />;
+    return <div className="h-screen bg-background" aria-hidden="true" />;
   }
 
   if (!isChromiumBrowser) {
     return <NonChromiumFallback />;
   }
 
-  return <MapContainer />;
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <LegendPanel />
+        <main className="flex-1 overflow-hidden">
+          <MapContainer />
+        </main>
+      </div>
+    </div>
+  );
 };

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * Icon button that toggles between light and dark mode via next-themes.
+ */
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+import type { ReactElement } from "react";
+
+/**
+ * A ghost icon button that toggles the active color scheme between light and dark.
+ *
+ * Reads and sets theme via next-themes `useTheme`. Defaults to treating an
+ * unresolved theme (pre-hydration) as light. The aria-label describes the
+ * action the button will perform, not the current state.
+ *
+ * @returns A sun or moon icon button depending on the current theme.
+ */
+export const DarkModeToggle = (): ReactElement => {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => {
+        setTheme(isDark ? "light" : "dark");
+      }}
+      aria-label={isDark ? "switch to light mode" : "switch to dark mode"}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * Application header with the app title, map toggle, and dark mode toggle.
+ */
+
+import { DarkModeToggle } from "@/components/DarkModeToggle";
+import { Button } from "@/components/ui/button";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/**
+ * The top application header bar.
+ *
+ * Contains:
+ * - App title using the Fraunces heading font
+ * - World / United States map toggle buttons
+ * - Dark mode toggle
+ *
+ * The map toggle buttons reflect the current `world` value from the Zustand
+ * store. Clicking one calls `setWorld` to switch views; MapContainer reacts
+ * to the store change and swaps the active map.
+ *
+ * @returns A sticky header rendered inside a `<header>` element.
+ */
+export const Header = (): ReactElement => {
+  const { world, setWorld } = useMapStore();
+
+  return (
+    <header
+      className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4"
+      data-screenshot="header"
+    >
+      <span className="font-heading text-xl font-semibold tracking-tight text-foreground">
+        Travel Buddy
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant={world ? "default" : "outline"}
+          size="sm"
+          onClick={() => {
+            setWorld(true);
+          }}
+          aria-pressed={world}
+        >
+          World
+        </Button>
+        <Button
+          variant={!world ? "default" : "outline"}
+          size="sm"
+          onClick={() => {
+            setWorld(false);
+          }}
+          aria-pressed={!world}
+        >
+          United States
+        </Button>
+      </div>
+      <DarkModeToggle />
+    </header>
+  );
+};

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Sidebar panel listing legend categories with color swatches and remove buttons.
+ */
+
+import { Trash2 } from "lucide-react";
+
+import { AddLegendModal } from "@/components/AddLegendModal";
+import { Button } from "@/components/ui/button";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/**
+ * Sidebar panel showing all legend categories.
+ *
+ * Each entry displays a color swatch and name. A trash button removes the
+ * category and unassigns it from all regions. The "Add category" button at
+ * the bottom opens the AddLegendModal.
+ *
+ * @returns A `<aside>` sidebar listing legend items and an add-category trigger.
+ */
+export const LegendPanel = (): ReactElement => {
+  const { legends, removeLegend } = useMapStore();
+
+  return (
+    <aside
+      className="flex w-56 shrink-0 flex-col gap-3 overflow-y-auto border-r border-border bg-surface p-4"
+      data-screenshot="legend-panel"
+    >
+      <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+        Legend
+      </h2>
+      <ul className="flex flex-col gap-1">
+        {legends.map((legend) => (
+          <li key={legend.id} className="flex items-center gap-2 rounded-md px-1 py-1">
+            <span
+              className="inline-block h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: legend.color }}
+              aria-hidden="true"
+            />
+            <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => {
+                removeLegend(legend.id);
+              }}
+              aria-label={`Remove ${legend.name}`}
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <AddLegendModal />
+    </aside>
+  );
+};

--- a/src/components/RegionPopover.tsx
+++ b/src/components/RegionPopover.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * Non-blocking floating card for assigning a legend and note to a map region.
+ */
+
+import { X } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/** Props for the RegionPopover component. */
+type Props = {
+  /** GeoJSON region identifier corresponding to a key in the store's regions map. */
+  regionId: string;
+  /** Human-readable region name shown as the card title. */
+  regionName: string;
+  /** Called when the user saves or dismisses the card. */
+  onClose: () => void;
+};
+
+/**
+ * A small floating card anchored to the bottom-right of the map container.
+ *
+ * Unlike a modal dialog this card has no backdrop overlay — the map remains
+ * fully interactive while it is open. Legend changes are applied immediately
+ * to the Zustand store. The note is committed when the user clicks Save.
+ *
+ * Render with `key={regionId}` in the parent so React remounts with fresh
+ * note state whenever the selected region changes.
+ *
+ * The SelectValue children explicitly render the swatch + name so that the
+ * trigger displays correctly even when the legend ID is a UUID — Radix Select
+ * cannot reliably extract display text from complex JSX children in SelectItem.
+ *
+ * @param props - Region identity and close callback.
+ * @returns A positioned card for legend assignment and note editing.
+ */
+export const RegionPopover = ({ regionId, regionName, onClose }: Props): ReactElement => {
+  const { legends, regions, assignRegion, unassignRegion, setRegionNote } = useMapStore();
+  const [note, setNote] = useState(regions[regionId]?.note ?? "");
+
+  const currentLegendId = regions[regionId]?.legendId || "none";
+  const currentLegend = legends.find((l) => l.id === currentLegendId);
+
+  const handleLegendChange = (value: string | null) => {
+    if (!value || value === "none") {
+      unassignRegion(regionId);
+    } else {
+      assignRegion(regionId, value);
+    }
+  };
+
+  const handleSave = () => {
+    setRegionNote(regionId, note);
+    onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={regionName}
+      className="absolute bottom-4 right-4 z-10 flex w-64 flex-col gap-3 rounded-xl border border-border bg-surface p-4 shadow-lg"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-foreground">{regionName}</h3>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-muted-foreground"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <Select value={currentLegendId} onValueChange={handleLegendChange}>
+        <SelectTrigger aria-label={`Assign legend to ${regionName}`}>
+          <SelectValue placeholder="Assign a legend...">
+            {currentLegend ? (
+              <span className="flex items-center gap-2">
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: currentLegend.color }}
+                  aria-hidden="true"
+                />
+                {currentLegend.name}
+              </span>
+            ) : currentLegendId !== "none" ? null : undefined}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="none">None</SelectItem>
+          {legends.map((legend) => (
+            <SelectItem key={legend.id} value={legend.id}>
+              <span className="flex items-center gap-2">
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: legend.color }}
+                  aria-hidden="true"
+                />
+                {legend.name}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Textarea
+        placeholder="Add a note about this region..."
+        value={note}
+        onChange={(e) => {
+          setNote(e.target.value);
+        }}
+        aria-label={`Note for ${regionName}`}
+        rows={3}
+      />
+      <Button onClick={handleSave}>Save</Button>
+    </div>
+  );
+};

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
 
 import { RegionDialog } from "@/components/RegionDialog";
+import { ZoomControls } from "@/components/ZoomControls";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
@@ -22,6 +23,9 @@ const HOVER_FILL = "#b8b2ab";
 
 /** The stroke color between countries. */
 const STROKE_COLOR = "#a09890";
+
+/** Maximum zoom level for the world map. */
+const MAX_ZOOM = 8;
 
 /** A region selected by the user, awaiting dialog interaction. */
 type SelectedRegion = {
@@ -47,23 +51,50 @@ const selectRegion = (id: string, name: string, setSelected: (r: SelectedRegion)
  *
  * Each country is colored by its assigned legend category. Clicking or
  * pressing Enter/Space on a country opens a RegionDialog for legend
- * assignment and note editing. Supports pan and zoom via ZoomableGroup.
+ * assignment and note editing. Supports pan and zoom via ZoomableGroup (both
+ * mouse/touch and the ZoomControls overlay buttons).
+ *
+ * Zoom and center are controlled: `onMoveEnd` syncs them back after user
+ * drag/pinch gestures, and ZoomControls callbacks update them programmatically.
  *
  * The GeoJSON is fetched lazily from /world.json (served from public/).
  *
- * @returns An interactive SVG world map with a region dialog overlay.
+ * @returns An interactive SVG world map with a region dialog overlay and zoom controls.
  */
 export const WorldMap = (): ReactElement => {
   const { legends, regions } = useMapStore();
   const [selected, setSelected] = useState<SelectedRegion | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [center, setCenter] = useState<[number, number]>([0, 0]);
 
   const legendColors = Object.fromEntries(legends.map((l) => [l.id, l.color]));
 
+  const handleZoomIn = () => {
+    setZoom((z) => Math.min(z * 1.5, MAX_ZOOM));
+  };
+
+  const handleZoomOut = () => {
+    setZoom((z) => Math.max(z / 1.5, 1));
+  };
+
+  const handleReset = () => {
+    setZoom(1);
+    setCenter([0, 0]);
+  };
+
   return (
     <>
-      <div className="h-full w-full" data-screenshot="world-map">
+      <div className="relative h-full w-full" data-screenshot="world-map">
         <ComposableMap projectionConfig={{ scale: 147 }} style={{ width: "100%", height: "100%" }}>
-          <ZoomableGroup>
+          <ZoomableGroup
+            zoom={zoom}
+            center={center}
+            maxZoom={MAX_ZOOM}
+            onMoveEnd={({ coordinates, zoom: newZoom }) => {
+              setCenter(coordinates);
+              setZoom(newZoom);
+            }}
+          >
             <Geographies geography={GEO_URL}>
               {({ geographies }) =>
                 geographies.map((geo) => {
@@ -115,6 +146,7 @@ export const WorldMap = (): ReactElement => {
             </Geographies>
           </ZoomableGroup>
         </ComposableMap>
+        <ZoomControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} onReset={handleReset} />
       </div>
       {selected && (
         <RegionDialog

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -7,7 +7,7 @@
 import { useState } from "react";
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
 
-import { RegionDialog } from "@/components/RegionDialog";
+import { RegionPopover } from "@/components/RegionPopover";
 import { ZoomControls } from "@/components/ZoomControls";
 import { useMapStore } from "@/store/mapStore";
 
@@ -149,11 +149,10 @@ export const WorldMap = (): ReactElement => {
         <ZoomControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} onReset={handleReset} />
       </div>
       {selected && (
-        <RegionDialog
+        <RegionPopover
           key={selected.id}
           regionId={selected.id}
           regionName={selected.name}
-          isOpen={true}
           onClose={() => {
             setSelected(null);
           }}

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Overlay zoom control buttons for the interactive map.
+ */
+
+import { Minus, Plus, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import type { ReactElement } from "react";
+
+/** Props for the ZoomControls component. */
+type Props = {
+  /** Called when the user clicks the zoom-in (+) button. */
+  onZoomIn: () => void;
+  /** Called when the user clicks the zoom-out (-) button. */
+  onZoomOut: () => void;
+  /** Called when the user clicks the reset button. */
+  onReset: () => void;
+};
+
+/**
+ * A vertically stacked set of zoom control buttons rendered as a map overlay.
+ *
+ * Buttons are positioned absolutely in the bottom-left corner of the map
+ * container. The component is purely presentational: callers own the zoom
+ * state and pass callbacks for each action.
+ *
+ * @param props - Callbacks for zoom in, zoom out, and reset.
+ * @returns Three icon buttons for map zoom control.
+ */
+export const ZoomControls = ({ onZoomIn, onZoomOut, onReset }: Props): ReactElement => (
+  <div className="absolute bottom-4 left-4 flex flex-col gap-1">
+    <Button variant="outline" size="icon" onClick={onZoomIn} aria-label="Zoom in">
+      <Plus className="h-4 w-4" />
+    </Button>
+    <Button variant="outline" size="icon" onClick={onZoomOut} aria-label="Zoom out">
+      <Minus className="h-4 w-4" />
+    </Button>
+    <Button variant="outline" size="icon" onClick={onReset} aria-label="Reset zoom">
+      <RotateCcw className="h-4 w-4" />
+    </Button>
+  </div>
+);

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/src/types/react-simple-maps.d.ts
+++ b/src/types/react-simple-maps.d.ts
@@ -50,14 +50,35 @@ declare module "react-simple-maps" {
     children?: ReactNode;
   }) => JSX.Element;
 
+  /** Coordinates and zoom level reported by ZoomableGroup move callbacks. */
+  type MoveEndResult = {
+    /** Current map center as [longitude, latitude]. */
+    coordinates: [number, number];
+    /** Current zoom level. */
+    zoom: number;
+  };
+
   /**
    * Adds pan and zoom behaviour to its child map layers.
    *
+   * When `zoom` and `center` are passed as props, ZoomableGroup operates in
+   * controlled mode: the parent owns the zoom/pan state and receives updates
+   * via `onMoveEnd`.
+   *
+   * @param zoom - Current zoom level (default 1).
+   * @param center - Geographic center as [longitude, latitude] (default [0, 0]).
+   * @param minZoom - Minimum allowed zoom level (default 1).
+   * @param maxZoom - Maximum allowed zoom level (default 8).
+   * @param onMoveEnd - Called when the user finishes a drag or pinch gesture.
    * @param children - Map layers to make pannable/zoomable.
    */
   export const ZoomableGroup: (props: {
+    zoom?: number;
+    center?: [number, number];
+    minZoom?: number;
+    maxZoom?: number;
+    onMoveEnd?: (result: MoveEndResult) => void;
     children?: ReactNode;
-    [key: string]: unknown;
   }) => JSX.Element;
 
   /**


### PR DESCRIPTION
## What changed

- **Header**: app title (Fraunces font), world/US map toggle with aria-pressed, dark mode toggle
- **Legend panel**: sidebar with color swatches, per-category remove buttons, and an "Add category" modal (name + color picker)
- **Zoom controls**: +/-/reset overlay buttons on both maps; ZoomableGroup now controlled (zoom + center synced via onMoveEnd); AmericaMap gains ZoomableGroup for pan/zoom parity with WorldMap
- **Theme**: ThemeProvider wired into layout.tsx; DarkModeToggle syncs with next-themes; Fraunces heading font added

## Screenshots
<!-- screenshots-start -->
### header

| Light (new) | Dark (new) |
|---|---|
| ![header light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-after-header-light.png) | ![header dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-after-header-dark.png) |

### legend-panel

| Light (new) | Dark (new) |
|---|---|
| ![legend-panel light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-after-legend-panel-light.png) | ![legend-panel dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-after-legend-panel-dark.png) |

### world-map

| Before | After |
|---|---|
| ![before](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-before-world-map-light.png) | ![after](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr20-after-world-map-light.png) |
<!-- screenshots-end -->