### PR TITLE
fix(map): switch world map to Mercator projection

### DIFF
--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -101,7 +101,11 @@ export const WorldMap = (): ReactElement => {
       data-screenshot="world-map"
       onClick={() => setSelected(null)}
     >
-      <ComposableMap projectionConfig={{ scale: 147 }} style={{ width: "100%", height: "100%" }}>
+      <ComposableMap
+        projection="geoMercator"
+        projectionConfig={{ scale: 153 }}
+        style={{ width: "100%", height: "100%" }}
+      >
         <PannableZoomableGroup
           zoom={zoom}
           center={center}


### PR DESCRIPTION
## What changed
- Switched `WorldMap` from the default Natural Earth projection to `geoMercator` at scale 153
- Natural Earth renders the full globe including Antarctica, leaving large dead areas above and below the continents; Mercator clips at ~85° latitude so landmass fills the viewport naturally

## Screenshots
<!-- screenshots-start -->
_Captured automatically by CI — push a commit to populate._
<!-- screenshots-end -->