### PR TITLE
fix(map): stabilize d3 zoom and fix mobile layout

### DIFF
--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -4,7 +4,7 @@
  * Interactive SVG US states map component.
  */
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   ComposableMap,
   Geographies,
@@ -74,6 +74,15 @@ export const AmericaMap = (): ReactElement => {
 
   const closePanel = () => setSelected(null);
 
+  /**
+   * Memoized move-end handler — stable reference prevents the d3 zoom
+   * instance from being torn down and re-created on every render.
+   */
+  const handleMoveEnd = useCallback(({ coordinates, zoom: newZoom }: MoveEndResult) => {
+    setCenter(coordinates);
+    setZoom(newZoom);
+  }, []);
+
   const handleZoomIn = () => {
     closePanel();
     setZoom((z) => Math.min(z * 1.5, MAX_ZOOM));
@@ -115,10 +124,7 @@ export const AmericaMap = (): ReactElement => {
           center={center}
           maxZoom={MAX_ZOOM}
           onMoveStart={closePanel}
-          onMoveEnd={({ coordinates, zoom: newZoom }: MoveEndResult) => {
-            setCenter(coordinates);
-            setZoom(newZoom);
-          }}
+          onMoveEnd={handleMoveEnd}
         >
           <Geographies geography={GEO_URL}>
             {({ geographies }) =>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -53,9 +53,9 @@ export const AppShell = (): ReactElement => {
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <Header />
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 flex-col-reverse overflow-hidden md:flex-row">
         <LegendPanel />
-        <main className="flex-1 overflow-hidden">
+        <main className="min-h-0 flex-1 overflow-hidden">
           <MapContainer />
         </main>
       </div>

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -29,15 +29,15 @@ export const LegendPanel = (): ReactElement => {
 
   return (
     <aside
-      className="flex w-56 shrink-0 flex-col gap-3 overflow-y-auto border-r border-border bg-surface p-4"
+      className="flex w-full shrink-0 flex-row items-center gap-2 overflow-x-auto border-t border-border bg-surface p-3 md:w-56 md:flex-col md:items-stretch md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-t-0 md:p-4"
       data-screenshot="legend-panel"
     >
-      <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+      <h2 className="hidden text-sm font-semibold uppercase tracking-wider text-muted-foreground md:block">
         Legend
       </h2>
-      <ul className="flex flex-col gap-1">
+      <ul className="flex flex-row items-center gap-2 md:flex-col md:gap-1">
         {legends.map((legend) => (
-          <li key={legend.id} className="flex items-center gap-2 rounded-md px-1 py-1">
+          <li key={legend.id} className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1">
             <span
               className="inline-block h-3 w-3 shrink-0 rounded-full"
               style={{ backgroundColor: legend.color }}

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -35,7 +35,7 @@ export const LegendPanel = (): ReactElement => {
       <h2 className="hidden text-sm font-semibold uppercase tracking-wider text-muted-foreground md:block">
         Legend
       </h2>
-      <ul className="flex flex-row items-center gap-2 md:flex-col md:gap-1">
+      <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
           <li key={legend.id} className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1">
             <span

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -4,7 +4,7 @@
  * Interactive SVG world map component.
  */
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   ComposableMap,
   Geographies,
@@ -70,6 +70,15 @@ export const WorldMap = (): ReactElement => {
 
   const closePanel = () => setSelected(null);
 
+  /**
+   * Memoized move-end handler — stable reference prevents the d3 zoom
+   * instance from being torn down and re-created on every render.
+   */
+  const handleMoveEnd = useCallback(({ coordinates, zoom: newZoom }: MoveEndResult) => {
+    setCenter(coordinates);
+    setZoom(newZoom);
+  }, []);
+
   const handleZoomIn = () => {
     closePanel();
     setZoom((z) => Math.min(z * 1.5, MAX_ZOOM));
@@ -111,10 +120,7 @@ export const WorldMap = (): ReactElement => {
           center={center}
           maxZoom={MAX_ZOOM}
           onMoveStart={closePanel}
-          onMoveEnd={({ coordinates, zoom: newZoom }: MoveEndResult) => {
-            setCenter(coordinates);
-            setZoom(newZoom);
-          }}
+          onMoveEnd={handleMoveEnd}
         >
           <Geographies geography={GEO_URL}>
             {({ geographies }) =>


### PR DESCRIPTION
## What changed

- Wraps \`onMoveEnd\` in \`useCallback\` in both WorldMap and AmericaMap so the d3 zoom instance is not torn down and re-created on every render, eliminating the null crash when clicking zoom buttons
- Switches the app shell to \`flex-col-reverse md:flex-row\` so on mobile the map fills the top of the screen and the legend appears as a compact horizontal strip below it

## Screenshots

<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->