### PR TITLE
feat(header): add clear all data button with inline confirmation

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -20,6 +20,7 @@ const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
 
 const setupStore = (world = true) => {
   const setWorld = jest.fn();
+  const clearData = jest.fn();
   mockUseMapStore.mockReturnValue({
     world,
     setWorld,
@@ -30,10 +31,10 @@ const setupStore = (world = true) => {
     assignRegion: jest.fn(),
     unassignRegion: jest.fn(),
     setRegionNote: jest.fn(),
-    clearData: jest.fn(),
+    clearData,
     hydrate: jest.fn().mockResolvedValue(undefined),
   } as ReturnType<typeof useMapStore>);
-  return { setWorld };
+  return { setWorld, clearData };
 };
 
 beforeEach(() => {
@@ -92,5 +93,46 @@ describe("Header", () => {
     setupStore();
     render(<Header />);
     expect(screen.getByRole("button", { name: /switch to dark mode/i })).toBeInTheDocument();
+  });
+
+  it("renders the clear all data button", () => {
+    setupStore();
+    render(<Header />);
+    expect(screen.getByRole("button", { name: /clear all data/i })).toBeInTheDocument();
+  });
+
+  it("shows inline confirmation when clear all data is clicked", async () => {
+    setupStore();
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
+    expect(screen.getByText(/clear all data\?/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm clear all data/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("calls clearData and dismisses confirmation when confirmed", async () => {
+    const { clearData } = setupStore();
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm clear all data/i }));
+    expect(clearData).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/clear all data\?/i)).not.toBeInTheDocument();
+  });
+
+  it("does not call clearData when cancel is clicked", async () => {
+    const { clearData } = setupStore();
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(clearData).not.toHaveBeenCalled();
+  });
+
+  it("dismisses confirmation without clearing when cancel is clicked", async () => {
+    setupStore();
+    render(<Header />);
+    await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText(/clear all data\?/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear all data/i })).toBeInTheDocument();
   });
 });

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Header } from "@/components/Header";
@@ -14,6 +14,32 @@ jest.mock("next-themes", () => ({
     systemTheme: undefined,
     forcedTheme: undefined,
   }),
+}));
+
+// Render AlertDialog inline (no portal) so jsdom can find dialog content.
+// The Header controls open state via props, so we only need to pass children through.
+jest.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (v: boolean) => void;
+  }) => (open ? <div>{children}</div> : null),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogAction: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  AlertDialogCancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
@@ -95,44 +121,35 @@ describe("Header", () => {
     expect(screen.getByRole("button", { name: /switch to dark mode/i })).toBeInTheDocument();
   });
 
-  it("renders the clear all data button", () => {
+  it("renders the clear all data trigger button", () => {
     setupStore();
     render(<Header />);
     expect(screen.getByRole("button", { name: /clear all data/i })).toBeInTheDocument();
   });
 
-  it("shows inline confirmation when clear all data is clicked", async () => {
+  it("opens the confirmation dialog when the clear button is clicked", async () => {
     setupStore();
     render(<Header />);
     await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
-    expect(screen.getByText(/clear all data\?/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /confirm clear all data/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /clear all data\?/i })).toBeInTheDocument();
+    expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument();
   });
 
-  it("calls clearData and dismisses confirmation when confirmed", async () => {
+  it("calls clearData when the dialog confirm button is clicked", async () => {
     const { clearData } = setupStore();
     render(<Header />);
     await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
-    await userEvent.click(screen.getByRole("button", { name: /confirm clear all data/i }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /clear all data/i }));
     expect(clearData).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/clear all data\?/i)).not.toBeInTheDocument();
   });
 
-  it("does not call clearData when cancel is clicked", async () => {
+  it("does not call clearData when the dialog cancel button is clicked", async () => {
     const { clearData } = setupStore();
     render(<Header />);
     await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
     expect(clearData).not.toHaveBeenCalled();
-  });
-
-  it("dismisses confirmation without clearing when cancel is clicked", async () => {
-    setupStore();
-    render(<Header />);
-    await userEvent.click(screen.getByRole("button", { name: /clear all data/i }));
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(screen.queryByText(/clear all data\?/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /clear all data/i })).toBeInTheDocument();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 /**
- * Application header with the app title, map toggle, and dark mode toggle.
+ * Application header with the app title, map toggle, dark mode toggle, and clear-data action.
  */
+
+import { Check, Trash2, X } from "lucide-react";
+import { useState } from "react";
 
 import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { Button } from "@/components/ui/button";
@@ -16,16 +19,26 @@ import type { ReactElement } from "react";
  * Contains:
  * - App title using the Fraunces heading font
  * - World / United States map toggle buttons
+ * - Clear-data button with inline confirmation
  * - Dark mode toggle
  *
  * The map toggle buttons reflect the current `world` value from the Zustand
  * store. Clicking one calls `setWorld` to switch views; MapContainer reacts
  * to the store change and swaps the active map.
  *
+ * The clear-data button uses a two-step inline confirm (same pattern as the
+ * legend remove button) to guard against accidental data loss.
+ *
  * @returns A sticky header rendered inside a `<header>` element.
  */
 export const Header = (): ReactElement => {
-  const { world, setWorld } = useMapStore();
+  const { world, setWorld, clearData } = useMapStore();
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const handleClearConfirm = () => {
+    clearData();
+    setIsConfirming(false);
+  };
 
   return (
     <header
@@ -57,7 +70,42 @@ export const Header = (): ReactElement => {
           United States
         </Button>
       </div>
-      <DarkModeToggle />
+      <div className="flex items-center gap-2">
+        {isConfirming ? (
+          <>
+            <span className="text-xs text-destructive">Clear all data?</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:text-destructive"
+              onClick={handleClearConfirm}
+              aria-label="Confirm clear all data"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground"
+              onClick={() => setIsConfirming(false)}
+              aria-label="Cancel"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-destructive"
+            onClick={() => setIsConfirming(true)}
+            aria-label="Clear all data"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+        <DarkModeToggle />
+      </div>
     </header>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,10 +4,20 @@
  * Application header with the app title, map toggle, dark mode toggle, and clear-data action.
  */
 
-import { Check, Trash2, X } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { DarkModeToggle } from "@/components/DarkModeToggle";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useMapStore } from "@/store/mapStore";
 
@@ -19,25 +29,22 @@ import type { ReactElement } from "react";
  * Contains:
  * - App title using the Fraunces heading font
  * - World / United States map toggle buttons
- * - Clear-data button with inline confirmation
+ * - Clear-data button that opens a confirmation dialog before wiping all state
  * - Dark mode toggle
  *
  * The map toggle buttons reflect the current `world` value from the Zustand
  * store. Clicking one calls `setWorld` to switch views; MapContainer reacts
  * to the store change and swaps the active map.
  *
- * The clear-data button uses a two-step inline confirm (same pattern as the
- * legend remove button) to guard against accidental data loss.
- *
  * @returns A sticky header rendered inside a `<header>` element.
  */
 export const Header = (): ReactElement => {
   const { world, setWorld, clearData } = useMapStore();
-  const [isConfirming, setIsConfirming] = useState(false);
+  const [isClearOpen, setIsClearOpen] = useState(false);
 
   const handleClearConfirm = () => {
     clearData();
-    setIsConfirming(false);
+    setIsClearOpen(false);
   };
 
   return (
@@ -71,39 +78,34 @@ export const Header = (): ReactElement => {
         </Button>
       </div>
       <div className="flex items-center gap-2">
-        {isConfirming ? (
-          <>
-            <span className="text-xs text-destructive">Clear all data?</span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-destructive hover:text-destructive"
-              onClick={handleClearConfirm}
-              aria-label="Confirm clear all data"
-            >
-              <Check className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground"
-              onClick={() => setIsConfirming(false)}
-              aria-label="Cancel"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </>
-        ) : (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-muted-foreground hover:text-destructive"
-            onClick={() => setIsConfirming(true)}
-            aria-label="Clear all data"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+          aria-label="Clear all data"
+          onClick={() => setIsClearOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+        <AlertDialog open={isClearOpen} onOpenChange={setIsClearOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Clear all data?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This removes all your legend categories and region assignments. It cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={handleClearConfirm}
+              >
+                Clear all data
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
         <DarkModeToggle />
       </div>
     </header>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm";
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+  return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};


### PR DESCRIPTION
## What changed

- Adds a trash icon button to the header's right side that triggers a two-step inline confirmation before calling \`clearData()\`
- Confirmation shows "Clear all data?" with confirm (check) and cancel (X) buttons — same pattern as the legend remove button
- Cancelling or confirming both dismiss the confirmation state; the trash icon returns to neutral styling after cancel

## Screenshots

<!-- screenshots-start -->
### header

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr25-before-header-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr25-after-header-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr25-before-header-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr25-after-header-dark.png) |
<!-- screenshots-end -->