### PR TITLE
feat(stats): add stats modal showing per-legend region counts

### DIFF
--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { StatsModal } from "@/components/StatsModal";
+import { useMapStore } from "@/store/mapStore";
+
+import { createLegend } from "../factories/createLegend";
+
+jest.mock("@/store/mapStore");
+
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (v: boolean) => void;
+  }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const visited = createLegend({ id: "visited", name: "Visited", color: "#16a34a" });
+const driven = createLegend({ id: "driven", name: "Driven", color: "#d97706" });
+
+const setupStore = (
+  legends = [visited, driven],
+  regions: Record<string, { legendId: string; note: string }> = {}
+) => {
+  mockUseMapStore.mockReturnValue({
+    legends,
+    regions,
+    world: true,
+    setWorld: jest.fn(),
+    addLegend: jest.fn(),
+    removeLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn().mockResolvedValue(undefined),
+  } as ReturnType<typeof useMapStore>);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("StatsModal", () => {
+  it("renders a view stats button", () => {
+    setupStore();
+    render(<StatsModal />);
+    expect(screen.getByRole("button", { name: /view stats/i })).toBeInTheDocument();
+  });
+
+  it("opens the dialog when the stats button is clicked", async () => {
+    setupStore();
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /stats/i })).toBeInTheDocument();
+  });
+
+  it("shows 'no regions marked yet' when nothing is assigned", async () => {
+    setupStore([visited, driven], {});
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/no regions marked yet/i)).toBeInTheDocument();
+  });
+
+  it("shows the total regions marked count", async () => {
+    setupStore([visited, driven], {
+      "840": { legendId: "visited", note: "" },
+      "250": { legendId: "visited", note: "" },
+      "276": { legendId: "driven", note: "" },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/3 regions marked/i)).toBeInTheDocument();
+  });
+
+  it("uses singular 'region' when exactly one is marked", async () => {
+    setupStore([visited], { "840": { legendId: "visited", note: "" } });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/1 region marked/i)).toBeInTheDocument();
+  });
+
+  it("renders a row for each legend category", async () => {
+    setupStore([visited, driven], {});
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText("Visited")).toBeInTheDocument();
+    expect(screen.getByText("Driven")).toBeInTheDocument();
+  });
+
+  it("shows the count for each legend", async () => {
+    setupStore([visited, driven], {
+      "840": { legendId: "visited", note: "" },
+      "250": { legendId: "visited", note: "" },
+      "276": { legendId: "driven", note: "" },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    const counts = screen.getAllByRole("listitem");
+    // Visited row shows count 2, Driven row shows count 1
+    expect(counts[0]).toHaveTextContent("2");
+    expect(counts[1]).toHaveTextContent("1");
+  });
+
+  it("shows progress bars for each legend", async () => {
+    setupStore([visited, driven], { "840": { legendId: "visited", note: "" } });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("aria-valuenow", "100");
+    expect(bars[1]).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("shows 'no categories yet' message when legend list is empty", async () => {
+    setupStore([], {});
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/no legend categories yet/i)).toBeInTheDocument();
+  });
+
+  it("ignores regions with no legendId when counting totals", async () => {
+    setupStore([visited], {
+      "840": { legendId: "visited", note: "" },
+      "250": { legendId: "", note: "some note" },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/1 region marked/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -12,11 +12,20 @@ jest.mock("@/components/ui/dialog", () => ({
   Dialog: ({
     children,
     open,
+    onOpenChange,
   }: {
     children: React.ReactNode;
     open?: boolean;
     onOpenChange?: (v: boolean) => void;
-  }) => (open ? <div>{children}</div> : null),
+  }) =>
+    open ? (
+      <div>
+        <button data-testid="mock-dialog-close" onClick={() => onOpenChange?.(false)}>
+          close dialog
+        </button>
+        {children}
+      </div>
+    ) : null,
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
@@ -132,6 +141,15 @@ describe("StatsModal", () => {
     expect(screen.getByText(/no legend categories yet/i)).toBeInTheDocument();
   });
 
+  it("closes the dialog when onOpenChange fires with false", async () => {
+    setupStore();
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("mock-dialog-close"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
   it("ignores regions with no legendId when counting totals", async () => {
     setupStore([visited], {
       "840": { legendId: "visited", note: "" },
@@ -140,5 +158,17 @@ describe("StatsModal", () => {
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
     expect(screen.getByText(/1 region marked/i)).toBeInTheDocument();
+  });
+
+  it("ignores regions assigned to a deleted legend", async () => {
+    setupStore([visited], {
+      "840": { legendId: "visited", note: "" },
+      "250": { legendId: "deleted-legend", note: "" },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(screen.getByText(/2 regions marked/i)).toBeInTheDocument();
+    const counts = screen.getAllByRole("listitem");
+    expect(counts[0]).toHaveTextContent("1");
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,10 +54,10 @@ export const Header = (): ReactElement => {
       className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4"
       data-screenshot="header"
     >
-      <span className="font-heading text-xl font-semibold tracking-tight text-foreground">
+      <span className="font-heading text-base font-semibold tracking-tight text-foreground md:text-xl">
         Travel Buddy
       </span>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1 md:gap-2">
         <Button
           variant={world ? "default" : "outline"}
           size="sm"
@@ -76,7 +76,8 @@ export const Header = (): ReactElement => {
           }}
           aria-pressed={!world}
         >
-          United States
+          <span className="hidden sm:inline">United States</span>
+          <span className="sm:hidden">US</span>
         </Button>
       </div>
       <div className="flex items-center gap-1">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 /**
- * Application header with the app title, map toggle, dark mode toggle, and clear-data action.
+ * Application header with the app title, map toggle, stats modal, dark mode toggle, and clear-data action.
  */
 
 import { Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { DarkModeToggle } from "@/components/DarkModeToggle";
+import { StatsModal } from "@/components/StatsModal";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,6 +30,7 @@ import type { ReactElement } from "react";
  * Contains:
  * - App title using the Fraunces heading font
  * - World / United States map toggle buttons
+ * - Stats modal button showing per-legend region counts
  * - Clear-data button that opens a confirmation dialog before wiping all state
  * - Dark mode toggle
  *
@@ -77,7 +79,8 @@ export const Header = (): ReactElement => {
           United States
         </Button>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1">
+        <StatsModal />
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * Modal showing per-legend region assignment counts and progress bars.
+ */
+
+import { BarChart2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/**
+ * Header button that opens a stats modal breaking down how many regions
+ * have been assigned to each legend category.
+ *
+ * Reads directly from the Zustand store — no props needed. The button
+ * and dialog are co-located here so the open state stays local.
+ *
+ * @returns A ghost icon button that opens the stats dialog when clicked.
+ */
+export const StatsModal = (): ReactElement => {
+  const { legends, regions } = useMapStore();
+  const [open, setOpen] = useState(false);
+
+  const assignedEntries = Object.values(regions).filter((r) => r.legendId);
+  const total = assignedEntries.length;
+
+  /** Count of assigned regions per legend id. */
+  const countsByLegend = Object.fromEntries(legends.map((l) => [l.id, 0]));
+  for (const entry of assignedEntries) {
+    if (entry.legendId in countsByLegend) {
+      countsByLegend[entry.legendId] = (countsByLegend[entry.legendId] ?? 0) + 1;
+    }
+  }
+
+  const totalLabel =
+    total === 0 ? "No regions marked yet." : `${total} region${total === 1 ? "" : "s"} marked`;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+        aria-label="View stats"
+        onClick={() => setOpen(true)}
+      >
+        <BarChart2 className="h-4 w-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Stats</DialogTitle>
+            <DialogDescription>{totalLabel}</DialogDescription>
+          </DialogHeader>
+          {legends.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No legend categories yet. Add some in the legend panel.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-3 pt-1">
+              {legends.map((legend) => {
+                const count = countsByLegend[legend.id] ?? 0;
+                const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+
+                return (
+                  <li key={legend.id} className="flex items-center gap-3">
+                    <span
+                      className="h-3 w-3 shrink-0 rounded-full"
+                      style={{ backgroundColor: legend.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="w-24 shrink-0 truncate text-sm text-foreground">
+                      {legend.name}
+                    </span>
+                    <div
+                      className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+                      role="progressbar"
+                      aria-valuenow={pct}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-label={`${legend.name} progress`}
+                    >
+                      <div
+                        className="h-full rounded-full transition-all duration-300"
+                        style={{ width: `${pct}%`, backgroundColor: legend.color }}
+                      />
+                    </div>
+                    <span className="w-6 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
+                      {count}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -36,10 +36,10 @@ export const StatsModal = (): ReactElement => {
   const total = assignedEntries.length;
 
   /** Count of assigned regions per legend id. */
-  const countsByLegend = Object.fromEntries(legends.map((l) => [l.id, 0]));
+  const countsByLegend: Record<string, number> = Object.fromEntries(legends.map((l) => [l.id, 0]));
   for (const entry of assignedEntries) {
     if (entry.legendId in countsByLegend) {
-      countsByLegend[entry.legendId] = (countsByLegend[entry.legendId] ?? 0) + 1;
+      countsByLegend[entry.legendId] += 1;
     }
   }
 
@@ -70,7 +70,7 @@ export const StatsModal = (): ReactElement => {
           ) : (
             <ul className="flex flex-col gap-3 pt-1">
               {legends.map((legend) => {
-                const count = countsByLegend[legend.id] ?? 0;
+                const count = countsByLegend[legend.id];
                 const pct = total > 0 ? Math.round((count / total) * 100) : 0;
 
                 return (


### PR DESCRIPTION
## What changed

- Adds a bar chart icon button to the header that opens a stats dialog
- Shows total regions marked and a per-legend breakdown: color swatch, name, count, and a color-matched progress bar showing proportion
- Handles empty states: no legends yet, and no regions marked yet

## Screenshots

<!-- screenshots-start -->
### header

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr26-before-header-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr26-after-header-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr26-before-header-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr26-after-header-dark.png) |
<!-- screenshots-end -->