### PR TITLE
feat(legend): inline edit for legend name and color

### DIFF
--- a/__tests__/components/LegendPanel.test.tsx
+++ b/__tests__/components/LegendPanel.test.tsx
@@ -21,9 +21,11 @@ const setupStore = (
   ]
 ) => {
   const removeLegend = jest.fn();
+  const updateLegend = jest.fn();
   mockUseMapStore.mockReturnValue({
     legends,
     removeLegend,
+    updateLegend,
     regions: {},
     world: true,
     setWorld: jest.fn(),
@@ -34,7 +36,7 @@ const setupStore = (
     clearData: jest.fn(),
     hydrate: jest.fn().mockResolvedValue(undefined),
   } as ReturnType<typeof useMapStore>);
-  return { removeLegend };
+  return { removeLegend, updateLegend };
 };
 
 beforeEach(() => {
@@ -121,5 +123,102 @@ describe("LegendPanel", () => {
     setupStore();
     render(<LegendPanel />);
     expect(document.querySelector("[data-screenshot='legend-panel']")).toBeInTheDocument();
+  });
+
+  it("renders an edit button for each legend", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByRole("button", { name: /edit visited/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit driven/i })).toBeInTheDocument();
+  });
+
+  it("shows the edit form when the pencil button is clicked", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    expect(screen.getByRole("textbox", { name: /legend name/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save visited/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel edit/i })).toBeInTheDocument();
+  });
+
+  it("pre-populates the edit form with the current name and color", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    expect(screen.getByRole("textbox", { name: /legend name/i })).toHaveValue("Visited");
+  });
+
+  it("calls updateLegend with new values when save is clicked", async () => {
+    const { updateLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    const input = screen.getByRole("textbox", { name: /legend name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "Been there");
+    await userEvent.click(screen.getByRole("button", { name: /save visited/i }));
+    expect(updateLegend).toHaveBeenCalledWith("visited", { name: "Been there", color: "#16a34a" });
+  });
+
+  it("falls back to the original name when saved with an empty name", async () => {
+    const { updateLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    await userEvent.clear(screen.getByRole("textbox", { name: /legend name/i }));
+    await userEvent.click(screen.getByRole("button", { name: /save visited/i }));
+    expect(updateLegend).toHaveBeenCalledWith("visited", { name: "Visited", color: "#16a34a" });
+  });
+
+  it("does not call updateLegend when cancel is clicked", async () => {
+    const { updateLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel edit/i }));
+    expect(updateLegend).not.toHaveBeenCalled();
+  });
+
+  it("restores the normal state after cancelling an edit", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel edit/i }));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText("Visited")).toBeInTheDocument();
+  });
+
+  it("saves on Enter key in the name input", async () => {
+    const { updateLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    const input = screen.getByRole("textbox", { name: /legend name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "Been there{Enter}");
+    expect(updateLegend).toHaveBeenCalledWith("visited", { name: "Been there", color: "#16a34a" });
+  });
+
+  it("cancels on Escape key in the name input", async () => {
+    const { updateLegend } = setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    await userEvent.keyboard("{Escape}");
+    expect(updateLegend).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("clears a pending remove confirmation when entering edit mode", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /remove visited/i }));
+    expect(screen.getByText(/remove\?/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /edit driven/i }));
+    expect(screen.queryByText(/remove\?/i)).not.toBeInTheDocument();
+  });
+
+  it("clears a pending edit when entering remove confirmation mode", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /edit visited/i }));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /remove driven/i }));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/store/mapStore.test.ts
+++ b/__tests__/store/mapStore.test.ts
@@ -134,6 +134,33 @@ describe("removeLegend", () => {
   });
 });
 
+describe("updateLegend", () => {
+  it("updates the name and color of the specified legend", () => {
+    act(() => {
+      useMapStore.getState().updateLegend("visited", { name: "Been there", color: "#7c3aed" });
+    });
+    const updated = useMapStore.getState().legends.find((l) => l.id === "visited");
+    expect(updated?.name).toBe("Been there");
+    expect(updated?.color).toBe("#7c3aed");
+  });
+
+  it("does not affect other legends", () => {
+    act(() => {
+      useMapStore.getState().updateLegend("visited", { name: "Been there", color: "#7c3aed" });
+    });
+    const driven = useMapStore.getState().legends.find((l) => l.id === "driven");
+    expect(driven?.name).toBe("Driven");
+    expect(driven?.color).toBe("#d97706");
+  });
+
+  it("calls saveState after updating", () => {
+    act(() => {
+      useMapStore.getState().updateLegend("visited", { name: "Been there", color: "#7c3aed" });
+    });
+    expect(mockSaveState).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("assignRegion", () => {
   it("creates a region entry with the given legend", () => {
     act(() => {

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 /**
- * Sidebar panel listing legend categories with color swatches and remove buttons.
+ * Sidebar panel listing legend categories with color swatches, inline edit, and remove buttons.
  */
 
-import { Check, Trash2, X } from "lucide-react";
+import { Check, Pencil, Trash2, X } from "lucide-react";
 import { useState } from "react";
 
 import { AddLegendModal } from "@/components/AddLegendModal";
@@ -16,16 +16,37 @@ import type { ReactElement } from "react";
 /**
  * Sidebar panel showing all legend categories.
  *
- * Each entry displays a color swatch and name. Clicking the trash button
- * enters an inline confirmation state — the item shows "Remove?" with confirm
- * and cancel buttons before calling removeLegend. The "Add category" button
- * at the bottom opens the AddLegendModal.
+ * Each entry displays a color swatch and name. Clicking the pencil icon
+ * enters inline edit mode: the swatch becomes a color picker and the name
+ * becomes a text input. Clicking the trash button enters inline remove
+ * confirmation before calling removeLegend. The "Add category" button at
+ * the bottom opens the AddLegendModal.
+ *
+ * Only one row can be in edit or confirm mode at a time — entering either
+ * state clears the other.
  *
  * @returns A `<aside>` sidebar listing legend items and an add-category trigger.
  */
 export const LegendPanel = (): ReactElement => {
-  const { legends, removeLegend } = useMapStore();
+  const { legends, removeLegend, updateLegend } = useMapStore();
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editColor, setEditColor] = useState("");
+
+  const startEdit = (id: string, name: string, color: string) => {
+    setEditId(id);
+    setEditName(name);
+    setEditColor(color);
+    setConfirmId(null);
+  };
+
+  const saveEdit = (id: string, originalName: string) => {
+    updateLegend(id, { name: editName.trim() || originalName, color: editColor });
+    setEditId(null);
+  };
+
+  const cancelEdit = () => setEditId(null);
 
   return (
     <aside
@@ -37,14 +58,58 @@ export const LegendPanel = (): ReactElement => {
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
-          <li key={legend.id} className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1">
-            <span
-              className="inline-block h-3 w-3 shrink-0 rounded-full"
-              style={{ backgroundColor: legend.color }}
-              aria-hidden="true"
-            />
-            {confirmId === legend.id ? (
+          <li key={legend.id} className="flex shrink-0 items-center gap-1 rounded-md px-1 py-1">
+            {editId === legend.id ? (
               <>
+                <input
+                  type="color"
+                  value={editColor}
+                  onChange={(e) => setEditColor(e.target.value)}
+                  className="h-6 w-6 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0"
+                  aria-label={`Color for ${legend.name}`}
+                />
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      saveEdit(legend.id, legend.name);
+                    }
+                    if (e.key === "Escape") {
+                      cancelEdit();
+                    }
+                  }}
+                  className="min-w-0 flex-1 rounded border border-border bg-background px-1 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+                  aria-label="Legend name"
+                  autoFocus
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 shrink-0 text-foreground"
+                  onClick={() => saveEdit(legend.id, legend.name)}
+                  aria-label={`Save ${legend.name}`}
+                >
+                  <Check className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 shrink-0 text-muted-foreground"
+                  onClick={cancelEdit}
+                  aria-label="Cancel edit"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </>
+            ) : confirmId === legend.id ? (
+              <>
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: legend.color }}
+                  aria-hidden="true"
+                />
                 <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
                 <Button
                   variant="ghost"
@@ -70,12 +135,29 @@ export const LegendPanel = (): ReactElement => {
               </>
             ) : (
               <>
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: legend.color }}
+                  aria-hidden="true"
+                />
                 <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
                 <Button
                   variant="ghost"
                   size="icon"
+                  className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                  onClick={() => startEdit(legend.id, legend.name, legend.color)}
+                  aria-label={`Edit ${legend.name}`}
+                >
+                  <Pencil className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
                   className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
-                  onClick={() => setConfirmId(legend.id)}
+                  onClick={() => {
+                    setConfirmId(legend.id);
+                    setEditId(null);
+                  }}
                   aria-label={`Remove ${legend.name}`}
                 >
                   <Trash2 className="h-3 w-3" />

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -64,6 +64,16 @@ export type MapStore = MapState & {
   removeLegend: (id: string) => void;
 
   /**
+   * Updates the name and color of an existing legend category.
+   *
+   * @param id - ID of the legend to update.
+   * @param updates - New name and color values to apply.
+   * @example
+   * store.updateLegend("visited", { name: "Been there", color: "#7c3aed" });
+   */
+  updateLegend: (id: string, updates: Omit<Legend, "id">) => void;
+
+  /**
    * Assigns a legend category to a region.
    *
    * @param regionId - GeoJSON region identifier (e.g. country ISO code or US state FIPS).
@@ -141,6 +151,12 @@ export const useMapStore = create<MapStore>()((set, get) => {
     addLegend: (input) => {
       const legend: Legend = { id: crypto.randomUUID(), ...input };
       const legends = [...get().legends, legend];
+      set({ legends });
+      void saveState(snapshot());
+    },
+
+    updateLegend: (id, updates) => {
+      const legends = get().legends.map((l) => (l.id === id ? { ...l, ...updates } : l));
       set({ legends });
       void saveState(snapshot());
     },


### PR DESCRIPTION
## What changed

- Adds a pencil icon to each legend row that switches it into inline edit mode
- Edit mode shows a native color picker and a text input pre-filled with the current values; Enter saves, Escape cancels
- Entering edit mode clears any pending remove confirmation and vice versa
- Adds `updateLegend(id, { name, color })` to the Zustand store

## Screenshots

<!-- screenshots-start -->
### legend-panel

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr28-before-legend-panel-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr28-after-legend-panel-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr28-before-legend-panel-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr28-after-legend-panel-dark.png) |
<!-- screenshots-end -->