### PR TITLE
feat(theme): atlas map color scheme for light and dark modes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,6 +57,12 @@
 :root {
   --radius: 0.625rem;
 
+  /* Map colors */
+  --map-ocean: #b8d4ec;
+  --map-land: #e8dcc8;
+  --map-land-hover: #d5c9b0;
+  --map-border: #b8a888;
+
   /* Custom palette */
   --background: #f6f4f0;
   --surface: #ede9e2;
@@ -99,6 +105,12 @@
 }
 
 .dark {
+  /* Map colors */
+  --map-ocean: #0d1520;
+  --map-land: #1e2d3d;
+  --map-land-hover: #263548;
+  --map-border: #2d4255;
+
   --background: #171a14;
   --surface: #1f2219;
   --border: #2d3328;

--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -26,14 +26,14 @@ import type { ComponentType, MouseEvent, ReactElement } from "react";
 
 const GEO_URL = "/us.json";
 
-/** The default fill for unassigned states. */
-const DEFAULT_FILL = "#d1cdc6";
+/** The default fill for unassigned states — resolves via CSS variable so it adapts to theme. */
+const DEFAULT_FILL = "var(--map-land)";
 
 /** The fill for unassigned states on hover. */
-const HOVER_FILL = "#b8b2ab";
+const HOVER_FILL = "var(--map-land-hover)";
 
 /** The stroke color between states. */
-const STROKE_COLOR = "#a09890";
+const STROKE_COLOR = "var(--map-border)";
 
 /** Maximum zoom level for the US map. */
 const MAX_ZOOM = 8;

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -61,7 +61,10 @@ export const MapContainer = (): ReactElement => {
   }, [hydrate]);
 
   return (
-    <div className="flex h-full w-full items-center justify-center bg-background">
+    <div
+      className="flex h-full w-full items-center justify-center"
+      style={{ backgroundColor: "var(--map-ocean)" }}
+    >
       {world ? <WorldMap /> : <AmericaMap />}
     </div>
   );

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -26,14 +26,14 @@ import type { ComponentType, MouseEvent, ReactElement } from "react";
 
 const GEO_URL = "/world.json";
 
-/** The default fill for unassigned regions. */
-const DEFAULT_FILL = "#d1cdc6";
+/** The default fill for unassigned regions — resolves via CSS variable so it adapts to theme. */
+const DEFAULT_FILL = "var(--map-land)";
 
 /** The fill for unassigned regions on hover. */
-const HOVER_FILL = "#b8b2ab";
+const HOVER_FILL = "var(--map-land-hover)";
 
 /** The stroke color between countries. */
-const STROKE_COLOR = "#a09890";
+const STROKE_COLOR = "var(--map-border)";
 
 /** Maximum zoom level for the world map. */
 const MAX_ZOOM = 8;


### PR DESCRIPTION
## What changed

- Adds `--map-ocean`, `--map-land`, `--map-land-hover`, and `--map-border` CSS variables to both light and dark themes
- Dark mode: deep navy ocean (`#0d1520`), slate-blue unvisited land (`#1e2d3d`) — colored regions pop against it
- Light mode: atlas blue water, warm parchment land to match the existing palette
- Both maps and the container background now respond automatically to theme changes

## Screenshots

<!-- screenshots-start -->
### world-map

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr29-before-world-map-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr29-after-world-map-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr29-before-world-map-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr29-after-world-map-dark.png) |
<!-- screenshots-end -->