### PR TITLE
feat(ui): segmented map toggle, colored legend borders, dashed add button

### DIFF
--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -74,7 +74,7 @@ describe("StatsModal", () => {
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /stats/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /your travels/i })).toBeInTheDocument();
   });
 
   it("shows 'no regions marked yet' when nothing is assigned", async () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,7 +154,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-background text-foreground font-heading;
   }
   code,
   pre {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,6 +57,12 @@
 :root {
   --radius: 0.625rem;
 
+  /* Map colors */
+  --map-ocean: #b8d4ec;
+  --map-land: #e8dcc8;
+  --map-land-hover: #d5c9b0;
+  --map-border: #b8a888;
+
   /* Custom palette */
   --background: #f6f4f0;
   --surface: #ede9e2;
@@ -99,6 +105,12 @@
 }
 
 .dark {
+  /* Map colors */
+  --map-ocean: #0d1520;
+  --map-land: #1e2d3d;
+  --map-land-hover: #263548;
+  --map-border: #2d4255;
+
   --background: #171a14;
   --surface: #1f2219;
   --border: #2d3328;

--- a/src/components/AddLegendModal.tsx
+++ b/src/components/AddLegendModal.tsx
@@ -60,10 +60,9 @@ export const AddLegendModal = (): ReactElement => {
     <>
       <Button
         size="sm"
-        className="w-full"
-        onClick={() => {
-          setIsOpen(true);
-        }}
+        variant="ghost"
+        className="shrink-0 border border-dashed border-border hover:border-accent hover:text-accent md:w-full"
+        onClick={() => setIsOpen(true)}
       >
         <Plus className="h-4 w-4" />
         Add category

--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -26,14 +26,14 @@ import type { ComponentType, MouseEvent, ReactElement } from "react";
 
 const GEO_URL = "/us.json";
 
-/** The default fill for unassigned states. */
-const DEFAULT_FILL = "#d1cdc6";
+/** The default fill for unassigned states — resolves via CSS variable so it adapts to theme. */
+const DEFAULT_FILL = "var(--map-land)";
 
 /** The fill for unassigned states on hover. */
-const HOVER_FILL = "#b8b2ab";
+const HOVER_FILL = "var(--map-land-hover)";
 
 /** The stroke color between states. */
-const STROKE_COLOR = "#a09890";
+const STROKE_COLOR = "var(--map-border)";
 
 /** Maximum zoom level for the US map. */
 const MAX_ZOOM = 8;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,28 +57,30 @@ export const Header = (): ReactElement => {
       <span className="font-heading text-base font-semibold tracking-tight text-foreground md:text-xl">
         Travel Buddy
       </span>
-      <div className="flex items-center gap-1 md:gap-2">
-        <Button
-          variant={world ? "default" : "outline"}
-          size="sm"
-          onClick={() => {
-            setWorld(true);
-          }}
+      <div className="flex items-center rounded-full border border-border bg-muted p-0.5">
+        <button
+          onClick={() => setWorld(true)}
           aria-pressed={world}
+          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+            world
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
         >
           World
-        </Button>
-        <Button
-          variant={!world ? "default" : "outline"}
-          size="sm"
-          onClick={() => {
-            setWorld(false);
-          }}
+        </button>
+        <button
+          onClick={() => setWorld(false)}
           aria-pressed={!world}
+          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+            !world
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
         >
           <span className="hidden sm:inline">United States</span>
           <span className="sm:hidden">US</span>
-        </Button>
+        </button>
       </div>
       <div className="flex items-center gap-1">
         <StatsModal />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,16 +57,14 @@ export const Header = (): ReactElement => {
       <span className="font-heading text-base font-semibold tracking-tight text-foreground md:text-xl">
         Travel Buddy
       </span>
-      <div className="relative flex items-center rounded-full border border-border bg-muted p-0.5">
-        <div
-          aria-hidden="true"
-          className={`pointer-events-none absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-background shadow-sm transition-transform duration-200 ease-in-out${!world ? " translate-x-full" : ""}`}
-        />
+      <div className="flex items-center rounded-full border border-border bg-muted p-0.5">
         <button
           onClick={() => setWorld(true)}
           aria-pressed={world}
-          className={`relative z-10 flex-1 whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-            world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+          className={`whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-all duration-150 ${
+            world
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
           }`}
         >
           World
@@ -74,8 +72,10 @@ export const Header = (): ReactElement => {
         <button
           onClick={() => setWorld(false)}
           aria-pressed={!world}
-          className={`relative z-10 flex-1 whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-            !world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+          className={`whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-all duration-150 ${
+            !world
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
           }`}
         >
           <span className="hidden sm:inline">United States</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,7 +65,7 @@ export const Header = (): ReactElement => {
         <button
           onClick={() => setWorld(true)}
           aria-pressed={world}
-          className={`relative z-10 flex-1 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+          className={`relative z-10 flex-1 whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-colors ${
             world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
           }`}
         >
@@ -74,7 +74,7 @@ export const Header = (): ReactElement => {
         <button
           onClick={() => setWorld(false)}
           aria-pressed={!world}
-          className={`relative z-10 flex-1 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+          className={`relative z-10 flex-1 whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-colors ${
             !world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
           }`}
         >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,14 +57,16 @@ export const Header = (): ReactElement => {
       <span className="font-heading text-base font-semibold tracking-tight text-foreground md:text-xl">
         Travel Buddy
       </span>
-      <div className="flex items-center rounded-full border border-border bg-muted p-0.5">
+      <div className="relative flex items-center rounded-full border border-border bg-muted p-0.5">
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-background shadow-sm transition-transform duration-200 ease-in-out${!world ? " translate-x-full" : ""}`}
+        />
         <button
           onClick={() => setWorld(true)}
           aria-pressed={world}
-          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-            world
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
+          className={`relative z-10 flex-1 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+            world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
           }`}
         >
           World
@@ -72,10 +74,8 @@ export const Header = (): ReactElement => {
         <button
           onClick={() => setWorld(false)}
           aria-pressed={!world}
-          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-            !world
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
+          className={`relative z-10 flex-1 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+            !world ? "text-foreground" : "text-muted-foreground hover:text-foreground"
           }`}
         >
           <span className="hidden sm:inline">United States</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,7 +54,7 @@ export const Header = (): ReactElement => {
       className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4"
       data-screenshot="header"
     >
-      <span className="font-heading text-base font-semibold tracking-tight text-foreground md:text-xl">
+      <span className="text-base font-semibold tracking-tight text-foreground md:text-xl">
         Travel Buddy
       </span>
       <div className="flex items-center rounded-full border border-border bg-muted p-0.5">

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -58,11 +58,7 @@ export const LegendPanel = (): ReactElement => {
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
-          <li
-            key={legend.id}
-            className="flex shrink-0 items-center gap-1 rounded-r-md border-l-[3px] px-1.5 py-1 transition-colors"
-            style={{ borderLeftColor: editId === legend.id ? editColor : legend.color }}
-          >
+          <li key={legend.id} className="flex shrink-0 items-center gap-1 rounded-md px-1 py-1">
             {editId === legend.id ? (
               <>
                 <input
@@ -109,6 +105,11 @@ export const LegendPanel = (): ReactElement => {
               </>
             ) : confirmId === legend.id ? (
               <>
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: legend.color }}
+                  aria-hidden="true"
+                />
                 <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
                 <Button
                   variant="ghost"
@@ -134,6 +135,11 @@ export const LegendPanel = (): ReactElement => {
               </>
             ) : (
               <>
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: legend.color }}
+                  aria-hidden="true"
+                />
                 <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
                 <Button
                   variant="ghost"

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -58,7 +58,11 @@ export const LegendPanel = (): ReactElement => {
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
-          <li key={legend.id} className="flex shrink-0 items-center gap-1 rounded-md px-1 py-1">
+          <li
+            key={legend.id}
+            className="flex shrink-0 items-center gap-1 rounded-r-md border-l-[3px] px-1.5 py-1 transition-colors"
+            style={{ borderLeftColor: editId === legend.id ? editColor : legend.color }}
+          >
             {editId === legend.id ? (
               <>
                 <input

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -56,7 +56,7 @@ export const LegendPanel = (): ReactElement => {
       className="flex w-full shrink-0 flex-row items-center gap-2 overflow-x-auto border-t border-border bg-surface p-3 md:w-56 md:flex-col md:items-stretch md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-t-0 md:p-4"
       data-screenshot="legend-panel"
     >
-      <h2 className="hidden border-b border-border pb-2 font-heading text-base font-semibold text-foreground md:block">
+      <h2 className="hidden border-b border-border pb-2 text-base font-semibold text-foreground md:block">
         Legend
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -109,11 +109,6 @@ export const LegendPanel = (): ReactElement => {
               </>
             ) : confirmId === legend.id ? (
               <>
-                <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: legend.color }}
-                  aria-hidden="true"
-                />
                 <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
                 <Button
                   variant="ghost"
@@ -139,11 +134,6 @@ export const LegendPanel = (): ReactElement => {
               </>
             ) : (
               <>
-                <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: legend.color }}
-                  aria-hidden="true"
-                />
                 <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
                 <Button
                   variant="ghost"

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -56,7 +56,7 @@ export const LegendPanel = (): ReactElement => {
       className="flex w-full shrink-0 flex-row items-center gap-2 overflow-x-auto border-t border-border bg-surface p-3 md:w-56 md:flex-col md:items-stretch md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-t-0 md:p-4"
       data-screenshot="legend-panel"
     >
-      <h2 className="hidden text-sm font-semibold uppercase tracking-wider text-muted-foreground md:block">
+      <h2 className="hidden border-b border-border pb-2 font-heading text-base font-semibold text-foreground md:block">
         Legend
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Check, Pencil, Trash2, X } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { AddLegendModal } from "@/components/AddLegendModal";
 import { Button } from "@/components/ui/button";
@@ -17,8 +17,8 @@ import type { ReactElement } from "react";
  * Sidebar panel showing all legend categories.
  *
  * Each entry displays a color swatch and name. Clicking the pencil icon
- * enters inline edit mode: the swatch becomes a color picker and the name
- * becomes a text input. Clicking the trash button enters inline remove
+ * enters inline edit mode: the swatch dot becomes a clickable button that
+ * opens a hidden color picker, and the name becomes a text input. Clicking the trash button enters inline remove
  * confirmation before calling removeLegend. The "Add category" button at
  * the bottom opens the AddLegendModal.
  *
@@ -48,6 +48,9 @@ export const LegendPanel = (): ReactElement => {
 
   const cancelEdit = () => setEditId(null);
 
+  /** Ref to the hidden color input — only one row is ever in edit mode at a time. */
+  const colorInputRef = useRef<HTMLInputElement>(null);
+
   return (
     <aside
       className="flex w-full shrink-0 flex-row items-center gap-2 overflow-x-auto border-t border-border bg-surface p-3 md:w-56 md:flex-col md:items-stretch md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-t-0 md:p-4"
@@ -62,11 +65,20 @@ export const LegendPanel = (): ReactElement => {
             {editId === legend.id ? (
               <>
                 <input
+                  ref={colorInputRef}
                   type="color"
                   value={editColor}
                   onChange={(e) => setEditColor(e.target.value)}
-                  className="h-6 w-6 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0"
+                  className="sr-only"
                   aria-label={`Color for ${legend.name}`}
+                  tabIndex={-1}
+                />
+                <button
+                  type="button"
+                  onClick={() => colorInputRef.current?.click()}
+                  className="inline-block h-3 w-3 shrink-0 cursor-pointer rounded-full ring-offset-1 hover:ring-2 hover:ring-border"
+                  style={{ backgroundColor: editColor }}
+                  aria-label={`Change color for ${legend.name}`}
                 />
                 <input
                   type="text"

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -76,7 +76,7 @@ export const LegendPanel = (): ReactElement => {
                 <button
                   type="button"
                   onClick={() => colorInputRef.current?.click()}
-                  className="inline-block h-3 w-3 shrink-0 cursor-pointer rounded-full ring-offset-1 hover:ring-2 hover:ring-border"
+                  className="h-5 w-5 shrink-0 cursor-pointer rounded ring-offset-1 hover:ring-2 hover:ring-border"
                   style={{ backgroundColor: editColor }}
                   aria-label={`Change color for ${legend.name}`}
                 />
@@ -118,7 +118,7 @@ export const LegendPanel = (): ReactElement => {
             ) : confirmId === legend.id ? (
               <>
                 <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  className="h-5 w-5 shrink-0 rounded"
                   style={{ backgroundColor: legend.color }}
                   aria-hidden="true"
                 />
@@ -148,7 +148,7 @@ export const LegendPanel = (): ReactElement => {
             ) : (
               <>
                 <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  className="h-5 w-5 shrink-0 rounded"
                   style={{ backgroundColor: legend.color }}
                   aria-hidden="true"
                 />

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -61,7 +61,7 @@ export const LegendPanel = (): ReactElement => {
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
-          <li key={legend.id} className="flex shrink-0 items-center gap-1 rounded-md px-1 py-1">
+          <li key={legend.id} className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1">
             {editId === legend.id ? (
               <>
                 <input

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -8,19 +8,21 @@ import { Check, Pencil, Trash2, X } from "lucide-react";
 import { useRef, useState } from "react";
 
 import { AddLegendModal } from "@/components/AddLegendModal";
-import { Button } from "@/components/ui/button";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
+
+/** Shared classes for the plain icon action buttons — no hover background box. */
+const iconBtn = "flex h-6 w-6 shrink-0 items-center justify-center transition-colors";
 
 /**
  * Sidebar panel showing all legend categories.
  *
  * Each entry displays a color swatch and name. Clicking the pencil icon
  * enters inline edit mode: the swatch dot becomes a clickable button that
- * opens a hidden color picker, and the name becomes a text input. Clicking the trash button enters inline remove
- * confirmation before calling removeLegend. The "Add category" button at
- * the bottom opens the AddLegendModal.
+ * opens a hidden color picker, and the name becomes a text input. Clicking
+ * the trash button enters inline remove confirmation before calling
+ * removeLegend. The "Add category" button at the bottom opens AddLegendModal.
  *
  * Only one row can be in edit or confirm mode at a time — entering either
  * state clears the other.
@@ -61,7 +63,10 @@ export const LegendPanel = (): ReactElement => {
       </h2>
       <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
         {legends.map((legend) => (
-          <li key={legend.id} className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1">
+          <li
+            key={legend.id}
+            className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-background/70"
+          >
             {editId === legend.id ? (
               <>
                 <input
@@ -96,24 +101,20 @@ export const LegendPanel = (): ReactElement => {
                   aria-label="Legend name"
                   autoFocus
                 />
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-foreground"
+                <button
+                  className={`${iconBtn} text-foreground hover:text-foreground/70`}
                   onClick={() => saveEdit(legend.id, legend.name)}
                   aria-label={`Save ${legend.name}`}
                 >
                   <Check className="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-muted-foreground"
+                </button>
+                <button
+                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
                   onClick={cancelEdit}
                   aria-label="Cancel edit"
                 >
                   <X className="h-3 w-3" />
-                </Button>
+                </button>
               </>
             ) : confirmId === legend.id ? (
               <>
@@ -123,10 +124,8 @@ export const LegendPanel = (): ReactElement => {
                   aria-hidden="true"
                 />
                 <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-destructive hover:text-destructive"
+                <button
+                  className={`${iconBtn} text-destructive hover:text-destructive/70`}
                   onClick={() => {
                     removeLegend(legend.id);
                     setConfirmId(null);
@@ -134,16 +133,14 @@ export const LegendPanel = (): ReactElement => {
                   aria-label={`Confirm remove ${legend.name}`}
                 >
                   <Check className="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-muted-foreground"
+                </button>
+                <button
+                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
                   onClick={() => setConfirmId(null)}
                   aria-label="Cancel"
                 >
                   <X className="h-3 w-3" />
-                </Button>
+                </button>
               </>
             ) : (
               <>
@@ -153,19 +150,15 @@ export const LegendPanel = (): ReactElement => {
                   aria-hidden="true"
                 />
                 <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                <button
+                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
                   onClick={() => startEdit(legend.id, legend.name, legend.color)}
                   aria-label={`Edit ${legend.name}`}
                 >
                   <Pencil className="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+                </button>
+                <button
+                  className={`${iconBtn} text-muted-foreground hover:text-destructive`}
                   onClick={() => {
                     setConfirmId(legend.id);
                     setEditId(null);
@@ -173,7 +166,7 @@ export const LegendPanel = (): ReactElement => {
                   aria-label={`Remove ${legend.name}`}
                 >
                   <Trash2 className="h-3 w-3" />
-                </Button>
+                </button>
               </>
             )}
           </li>

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -61,7 +61,10 @@ export const MapContainer = (): ReactElement => {
   }, [hydrate]);
 
   return (
-    <div className="flex h-full w-full items-center justify-center bg-background">
+    <div
+      className="flex h-full w-full items-center justify-center"
+      style={{ backgroundColor: "var(--map-ocean)" }}
+    >
       {world ? <WorldMap /> : <AmericaMap />}
     </div>
   );

--- a/src/components/RegionPanel.tsx
+++ b/src/components/RegionPanel.tsx
@@ -61,11 +61,11 @@ export const RegionPanel = ({ regionId, regionName, position, onClose }: Props):
       role="dialog"
       aria-label={regionName}
       style={{ left, top, width: PANEL_WIDTH }}
-      className="absolute z-10 rounded-xl border border-border bg-surface p-3 shadow-lg"
+      className="absolute z-10 rounded-2xl border border-border bg-surface p-3 shadow-xl"
       onClick={(e) => e.stopPropagation()}
     >
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground">{regionName}</h3>
+        <h3 className="font-heading text-base font-semibold text-foreground">{regionName}</h3>
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/RegionPanel.tsx
+++ b/src/components/RegionPanel.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 /**
- * Floating chip panel for assigning a legend category to a map region.
+ * Floating callout panel for assigning a legend category to a map region.
  * Anchored at the coordinates where the user clicked on the map.
  */
 
-import { X } from "lucide-react";
+import { MapPin, X } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
@@ -28,9 +27,10 @@ type Props = {
 };
 
 /**
- * Chip-based floating panel for assigning a legend to a map region.
+ * Chip-based floating callout for assigning a legend to a map region.
  *
- * Positioned at the click coordinates inside the map container. Each legend
+ * Positioned at the click coordinates inside the map container. A small
+ * upward-pointing arrow connects the panel to the click point. Each legend
  * renders as a colored chip — clicking an unassigned chip assigns it; clicking
  * the currently assigned chip removes the assignment. Changes apply immediately
  * to the Zustand store (no Save/Cancel).
@@ -39,11 +39,12 @@ type Props = {
  * store read whenever the selected region changes.
  *
  * @param props - Region identity, click position, and close callback.
- * @returns A positioned floating panel for legend assignment.
+ * @returns A positioned floating callout panel for legend assignment.
  */
 export const RegionPanel = ({ regionId, regionName, position, onClose }: Props): ReactElement => {
   const { legends, regions, assignRegion, unassignRegion } = useMapStore();
   const currentLegendId = regions[regionId]?.legendId ?? null;
+  const currentLegend = legends.find((l) => l.id === currentLegendId);
 
   const handleLegendClick = (legendId: string) => {
     if (currentLegendId === legendId) {
@@ -61,20 +62,29 @@ export const RegionPanel = ({ regionId, regionName, position, onClose }: Props):
       role="dialog"
       aria-label={regionName}
       style={{ left, top, width: PANEL_WIDTH }}
-      className="absolute z-10 rounded-2xl border border-border bg-surface p-3 shadow-xl"
+      className="animate-in fade-in slide-in-from-bottom-1 absolute z-10 rounded-2xl border border-border/60 bg-surface p-3 shadow-xl duration-150"
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-base font-semibold text-foreground">{regionName}</h3>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-5 w-5 text-muted-foreground"
+      <div
+        aria-hidden="true"
+        className="absolute -top-1.5 left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 border-l border-t border-border/60 bg-surface"
+      />
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <MapPin
+            className="h-3.5 w-3.5 shrink-0"
+            style={{ color: currentLegend?.color ?? "var(--color-text-muted)" }}
+            aria-hidden="true"
+          />
+          <h3 className="truncate text-base font-semibold text-foreground">{regionName}</h3>
+        </div>
+        <button
+          className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
           onClick={onClose}
           aria-label="Close"
         >
           <X className="h-3 w-3" />
-        </Button>
+        </button>
       </div>
       {legends.length === 0 ? (
         <p className="text-xs text-muted-foreground">No legends yet — add one in the panel.</p>
@@ -87,7 +97,7 @@ export const RegionPanel = ({ regionId, regionName, position, onClose }: Props):
               aria-pressed={currentLegendId === legend.id}
               aria-label={legend.name}
               onClick={() => handleLegendClick(legend.id)}
-              className={`rounded-full px-2.5 py-0.5 text-xs font-medium text-white transition-opacity ${
+              className={`rounded-md px-3 py-1 text-sm font-medium text-white transition-opacity ${
                 currentLegendId === legend.id
                   ? "opacity-100 ring-2 ring-white/50 ring-offset-1"
                   : "opacity-60 hover:opacity-90"

--- a/src/components/RegionPanel.tsx
+++ b/src/components/RegionPanel.tsx
@@ -65,7 +65,7 @@ export const RegionPanel = ({ regionId, regionName, position, onClose }: Props):
       onClick={(e) => e.stopPropagation()}
     >
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="font-heading text-base font-semibold text-foreground">{regionName}</h3>
+        <h3 className="text-base font-semibold text-foreground">{regionName}</h3>
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -60,7 +60,7 @@ export const StatsModal = (): ReactElement => {
       <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Stats</DialogTitle>
+            <DialogTitle>Your Travels</DialogTitle>
             <DialogDescription>{totalLabel}</DialogDescription>
           </DialogHeader>
           {legends.length === 0 ? (

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -60,7 +60,7 @@ export const StatsModal = (): ReactElement => {
       <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Stats</DialogTitle>
+            <DialogTitle className="font-heading">Stats</DialogTitle>
             <DialogDescription>{totalLabel}</DialogDescription>
           </DialogHeader>
           {legends.length === 0 ? (
@@ -76,7 +76,7 @@ export const StatsModal = (): ReactElement => {
                 return (
                   <li key={legend.id} className="flex items-center gap-3">
                     <span
-                      className="h-3 w-3 shrink-0 rounded-full"
+                      className="h-4 w-4 shrink-0 rounded"
                       style={{ backgroundColor: legend.color }}
                       aria-hidden="true"
                     />

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -60,7 +60,7 @@ export const StatsModal = (): ReactElement => {
       <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle className="font-heading">Stats</DialogTitle>
+            <DialogTitle>Stats</DialogTitle>
             <DialogDescription>{totalLabel}</DialogDescription>
           </DialogHeader>
           {legends.length === 0 ? (

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -26,14 +26,14 @@ import type { ComponentType, MouseEvent, ReactElement } from "react";
 
 const GEO_URL = "/world.json";
 
-/** The default fill for unassigned regions. */
-const DEFAULT_FILL = "#d1cdc6";
+/** The default fill for unassigned regions — resolves via CSS variable so it adapts to theme. */
+const DEFAULT_FILL = "var(--map-land)";
 
 /** The fill for unassigned regions on hover. */
-const HOVER_FILL = "#b8b2ab";
+const HOVER_FILL = "var(--map-land-hover)";
 
 /** The stroke color between countries. */
-const STROKE_COLOR = "#a09890";
+const STROKE_COLOR = "var(--map-border)";
 
 /** Maximum zoom level for the world map. */
 const MAX_ZOOM = 8;

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -6,8 +6,6 @@
 
 import { Minus, Plus, RotateCcw } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-
 import type { ReactElement } from "react";
 
 /** Props for the ZoomControls component. */
@@ -20,26 +18,39 @@ type Props = {
   onReset: () => void;
 };
 
+/** Shared classes for each control button in the cluster. */
+const clusterBtn =
+  "flex h-9 w-9 items-center justify-center text-foreground/60 transition-colors hover:bg-background hover:text-foreground";
+
 /**
- * A vertically stacked set of zoom control buttons rendered as a map overlay.
+ * A vertically grouped map navigation cluster rendered as a map overlay.
  *
- * Buttons are positioned absolutely in the bottom-left corner of the map
- * container. The component is purely presentational: callers own the zoom
- * state and pass callbacks for each action.
+ * The three controls (zoom in, zoom out, reset) are presented as a single
+ * card unit with hairline dividers, positioned in the bottom-left corner of
+ * the map container. Callers own the zoom state and pass callbacks for each
+ * action.
  *
  * @param props - Callbacks for zoom in, zoom out, and reset.
- * @returns Three icon buttons for map zoom control.
+ * @returns A grouped card of map zoom controls.
  */
 export const ZoomControls = ({ onZoomIn, onZoomOut, onReset }: Props): ReactElement => (
-  <div className="absolute bottom-4 left-4 flex flex-col gap-1">
-    <Button variant="outline" size="icon" onClick={onZoomIn} aria-label="Zoom in">
+  <div className="absolute bottom-4 left-4 flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-md">
+    <button
+      className={`${clusterBtn} border-b border-border`}
+      onClick={onZoomIn}
+      aria-label="Zoom in"
+    >
       <Plus className="h-4 w-4" />
-    </Button>
-    <Button variant="outline" size="icon" onClick={onZoomOut} aria-label="Zoom out">
+    </button>
+    <button
+      className={`${clusterBtn} border-b border-border`}
+      onClick={onZoomOut}
+      aria-label="Zoom out"
+    >
       <Minus className="h-4 w-4" />
-    </Button>
-    <Button variant="outline" size="icon" onClick={onReset} aria-label="Reset zoom">
-      <RotateCcw className="h-4 w-4" />
-    </Button>
+    </button>
+    <button className={clusterBtn} onClick={onReset} aria-label="Reset zoom">
+      <RotateCcw className="h-3.5 w-3.5" />
+    </button>
   </div>
 );

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -34,7 +34,10 @@ const clusterBtn =
  * @returns A grouped card of map zoom controls.
  */
 export const ZoomControls = ({ onZoomIn, onZoomOut, onReset }: Props): ReactElement => (
-  <div className="absolute bottom-4 left-4 flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-md">
+  <div
+    className="absolute bottom-4 left-4 flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-md"
+    data-screenshot="zoom-controls"
+  >
     <button
       className={`${clusterBtn} border-b border-border`}
       onClick={onZoomIn}


### PR DESCRIPTION
## What changed
- Header World/US toggle replaced with a pill segmented control (active tab fades in with `bg-background + shadow-sm`)
- Fraunces serif used as the default body font throughout — removed per-component overrides
- Region popup redesigned as a map callout: upward arrow anchors it to the click point, fade+slide entrance animation, map pin icon colored to the assigned legend, larger chips
- Legend panel rows get a subtle warm hover background; pencil/trash/check/X icons are now plain buttons with no hover background box
- Color swatches changed from circle dots to rounded squares, sized to match icon buttons
- Zoom controls redesigned as a single unified card cluster with hairline dividers
- Stats modal title changed to "Your Travels"
- "Add category" trigger styled as a dashed ghost button

## Screenshots
<!-- screenshots-start -->
### header

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-header-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-header-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-header-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-header-dark.png) |

### legend-panel

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-legend-panel-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-legend-panel-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-legend-panel-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-legend-panel-dark.png) |

### world-map

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-world-map-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-world-map-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-before-world-map-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-world-map-dark.png) |

### zoom-controls

| Light (new) | Dark (new) |
|---|---|
| ![zoom-controls light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-zoom-controls-light.png) | ![zoom-controls dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr30-after-zoom-controls-dark.png) |
<!-- screenshots-end -->