### PR TITLE
feat(stats): split World/US with hoverable donut charts; fix long region names

### DIFF
--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { StatsModal } from "@/components/StatsModal";
@@ -41,7 +41,7 @@ const driven = createLegend({ id: "driven", name: "Driven", color: "#d97706" });
 
 const setupStore = (
   legends = [visited, driven],
-  regions: Record<string, { legendId: string; note: string }> = {}
+  regions: Record<string, { legendId: string; note: string; world?: boolean }> = {}
 ) => {
   mockUseMapStore.mockReturnValue({
     legends,
@@ -50,6 +50,7 @@ const setupStore = (
     setWorld: jest.fn(),
     addLegend: jest.fn(),
     removeLegend: jest.fn(),
+    updateLegend: jest.fn(),
     assignRegion: jest.fn(),
     unassignRegion: jest.fn(),
     setRegionNote: jest.fn(),
@@ -102,15 +103,15 @@ describe("StatsModal", () => {
     expect(screen.getByText(/1 region marked/i)).toBeInTheDocument();
   });
 
-  it("renders a row for each legend category", async () => {
-    setupStore([visited, driven], {});
+  it("shows World and United States section labels", async () => {
+    setupStore([visited], {});
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
-    expect(screen.getByText("Visited")).toBeInTheDocument();
-    expect(screen.getByText("Driven")).toBeInTheDocument();
+    expect(screen.getByText("World")).toBeInTheDocument();
+    expect(screen.getByText("United States")).toBeInTheDocument();
   });
 
-  it("shows the count for each legend", async () => {
+  it("shows correct counts in the world section for regions without a world flag", async () => {
     setupStore([visited, driven], {
       "840": { legendId: "visited", note: "" },
       "250": { legendId: "visited", note: "" },
@@ -118,20 +119,24 @@ describe("StatsModal", () => {
     });
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
-    const counts = screen.getAllByRole("listitem");
-    // Visited row shows count 2, Driven row shows count 1
-    expect(counts[0]).toHaveTextContent("2");
-    expect(counts[1]).toHaveTextContent("1");
+    const worldSection = screen.getByTestId("stats-world");
+    const items = within(worldSection).getAllByRole("listitem");
+    expect(items[0]).toHaveTextContent("2");
+    expect(items[1]).toHaveTextContent("1");
   });
 
-  it("shows progress bars for each legend", async () => {
-    setupStore([visited, driven], { "840": { legendId: "visited", note: "" } });
+  it("routes world=true entries to the world section and world=false to US", async () => {
+    setupStore([visited], {
+      "840": { legendId: "visited", note: "", world: true },
+      "01": { legendId: "visited", note: "", world: false },
+      "48": { legendId: "visited", note: "", world: false },
+    });
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
-    const bars = screen.getAllByRole("progressbar");
-    expect(bars).toHaveLength(2);
-    expect(bars[0]).toHaveAttribute("aria-valuenow", "100");
-    expect(bars[1]).toHaveAttribute("aria-valuenow", "0");
+    const worldSection = screen.getByTestId("stats-world");
+    const usSection = screen.getByTestId("stats-us");
+    expect(within(worldSection).getByRole("listitem")).toHaveTextContent("1");
+    expect(within(usSection).getByRole("listitem")).toHaveTextContent("2");
   });
 
   it("shows 'no categories yet' message when legend list is empty", async () => {
@@ -168,7 +173,7 @@ describe("StatsModal", () => {
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
     expect(screen.getByText(/2 regions marked/i)).toBeInTheDocument();
-    const counts = screen.getAllByRole("listitem");
-    expect(counts[0]).toHaveTextContent("1");
+    const worldSection = screen.getByTestId("stats-world");
+    expect(within(worldSection).getByRole("listitem")).toHaveTextContent("1");
   });
 });

--- a/__tests__/store/mapStore.test.ts
+++ b/__tests__/store/mapStore.test.ts
@@ -122,7 +122,11 @@ describe("removeLegend", () => {
     act(() => {
       useMapStore.getState().removeLegend("visited");
     });
-    expect(useMapStore.getState().regions["US-NY"]).toEqual({ legendId: "driven", note: "" });
+    expect(useMapStore.getState().regions["US-NY"]).toEqual({
+      legendId: "driven",
+      note: "",
+      world: true,
+    });
     expect(useMapStore.getState().regions["US-CA"]).toBeUndefined();
   });
 
@@ -166,7 +170,11 @@ describe("assignRegion", () => {
     act(() => {
       useMapStore.getState().assignRegion("FR", "visited");
     });
-    expect(useMapStore.getState().regions["FR"]).toEqual({ legendId: "visited", note: "" });
+    expect(useMapStore.getState().regions["FR"]).toEqual({
+      legendId: "visited",
+      note: "",
+      world: true,
+    });
   });
 
   it("preserves an existing note when reassigning the legend", () => {
@@ -179,7 +187,11 @@ describe("assignRegion", () => {
     act(() => {
       useMapStore.getState().assignRegion("FR", "driven");
     });
-    expect(useMapStore.getState().regions["FR"]).toEqual({ legendId: "driven", note: "Paris!" });
+    expect(useMapStore.getState().regions["FR"]).toEqual({
+      legendId: "driven",
+      note: "Paris!",
+      world: true,
+    });
   });
 
   it("calls saveState after assigning", () => {

--- a/src/components/RegionPanel.tsx
+++ b/src/components/RegionPanel.tsx
@@ -76,7 +76,7 @@ export const RegionPanel = ({ regionId, regionName, position, onClose }: Props):
             style={{ color: currentLegend?.color ?? "var(--color-text-muted)" }}
             aria-hidden="true"
           />
-          <h3 className="truncate text-base font-semibold text-foreground">{regionName}</h3>
+          <h3 className="text-base font-semibold text-foreground">{regionName}</h3>
         </div>
         <button
           className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 /**
- * Modal showing per-legend region assignment counts and progress bars.
+ * Modal showing per-legend region counts and donut charts, split between
+ * the world map and the US states map.
  */
 
 import { BarChart2 } from "lucide-react";
@@ -17,14 +18,237 @@ import {
 } from "@/components/ui/dialog";
 import { useMapStore } from "@/store/mapStore";
 
+import type { Legend, RegionEntry } from "@/types";
 import type { ReactElement } from "react";
 
+// ─── Donut chart ─────────────────────────────────────────────────────────────
+
+/** One arc segment in the donut chart. */
+type DonutSegment = {
+  /** Display name of the legend category. */
+  name: string;
+  /** CSS hex color for the arc. */
+  color: string;
+  /** Number of regions assigned to this category. */
+  count: number;
+};
+
+/** Props for DonutChart. */
+type DonutChartProps = {
+  /** All legend categories with their counts for this map section. */
+  segments: DonutSegment[];
+  /** Total assigned regions in this section. */
+  total: number;
+};
+
+/** Outer radius of the donut ring (SVG units). */
+const OUTER_R = 52;
+/** Inner radius of the donut hole (SVG units). */
+const INNER_R = 34;
+/** Side length of the square SVG canvas. */
+const CHART_SIZE = 120;
+/** Center of the SVG canvas. */
+const CX = CHART_SIZE / 2;
+const CY = CHART_SIZE / 2;
+
 /**
- * Header button that opens a stats modal breaking down how many regions
- * have been assigned to each legend category.
+ * Converts an angle and radius to a Cartesian point on the chart.
  *
- * Reads directly from the Zustand store — no props needed. The button
- * and dialog are co-located here so the open state stays local.
+ * @param angle - Angle in radians, measured from the positive x-axis.
+ * @param r - Radius from the chart center.
+ * @returns x/y coordinates relative to the SVG origin.
+ */
+const polar = (angle: number, r: number): { x: number; y: number } => ({
+  x: CX + r * Math.cos(angle),
+  y: CY + r * Math.sin(angle),
+});
+
+/**
+ * Builds the SVG `d` attribute for a donut arc between two angles.
+ *
+ * @param startAngle - Start angle in radians.
+ * @param endAngle - End angle in radians.
+ * @returns SVG path string for the arc segment.
+ */
+const buildArcPath = (startAngle: number, endAngle: number): string => {
+  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  const o1 = polar(startAngle, OUTER_R);
+  const o2 = polar(endAngle, OUTER_R);
+  const i2 = polar(endAngle, INNER_R);
+  const i1 = polar(startAngle, INNER_R);
+  return [
+    `M ${o1.x} ${o1.y}`,
+    `A ${OUTER_R} ${OUTER_R} 0 ${largeArc} 1 ${o2.x} ${o2.y}`,
+    `L ${i2.x} ${i2.y}`,
+    `A ${INNER_R} ${INNER_R} 0 ${largeArc} 0 ${i1.x} ${i1.y}`,
+    "Z",
+  ].join(" ");
+};
+
+/**
+ * SVG donut chart with a hoverable legend breakdown and total in the center.
+ *
+ * Hovering an arc segment dims the others and shows the hovered category's
+ * name and count in the center hole. When nothing is hovered, the center
+ * shows the total assigned count for this map section.
+ *
+ * @param props - Segment data and total count.
+ * @returns An inline SVG donut chart.
+ */
+const DonutChart = ({ segments, total }: DonutChartProps): ReactElement => {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  const activeSegments = segments.filter((s) => s.count > 0);
+
+  let currentAngle = -Math.PI / 2;
+  const arcs = activeSegments.map((seg, i) => {
+    const sweep = (seg.count / total) * 2 * Math.PI;
+    const startAngle = currentAngle;
+    // Clamp slightly under 2π to keep the path valid when one segment fills the ring.
+    const endAngle = currentAngle + Math.min(sweep, 2 * Math.PI - 0.001);
+    currentAngle += sweep;
+    return { ...seg, path: buildArcPath(startAngle, endAngle), index: i };
+  });
+
+  const hovered = hoveredIndex !== null ? arcs[hoveredIndex] : null;
+
+  return (
+    <svg
+      width={CHART_SIZE}
+      height={CHART_SIZE}
+      viewBox={`0 0 ${CHART_SIZE} ${CHART_SIZE}`}
+      role="img"
+      aria-label={`${total} regions assigned`}
+    >
+      {total === 0 ? (
+        <circle cx={CX} cy={CY} r={OUTER_R} fill="var(--muted)" opacity={0.35} />
+      ) : (
+        arcs.map((arc) => (
+          <path
+            key={arc.index}
+            d={arc.path}
+            fill={arc.color}
+            style={{
+              opacity: hoveredIndex === null || hoveredIndex === arc.index ? 1 : 0.35,
+              transition: "opacity 150ms",
+            }}
+            onMouseEnter={() => setHoveredIndex(arc.index)}
+            onMouseLeave={() => setHoveredIndex(null)}
+            className="cursor-pointer"
+          />
+        ))
+      )}
+      <circle cx={CX} cy={CY} r={INNER_R} fill="var(--card)" />
+      <text
+        x={CX}
+        y={CY - 4}
+        textAnchor="middle"
+        style={{
+          fontSize: "18px",
+          fontWeight: "700",
+          fill: "var(--foreground)",
+          fontFamily: "var(--font-heading)",
+        }}
+      >
+        {hovered?.count ?? total}
+      </text>
+      <text
+        x={CX}
+        y={CY + 13}
+        textAnchor="middle"
+        style={{
+          fontSize: "10px",
+          fill: "var(--muted-foreground)",
+          fontFamily: "var(--font-heading)",
+        }}
+      >
+        {hovered?.name ?? "total"}
+      </text>
+    </svg>
+  );
+};
+
+// ─── Map section ─────────────────────────────────────────────────────────────
+
+/** Props for MapSection. */
+type MapSectionProps = {
+  /** Primary label for the section, e.g. "World". */
+  title: string;
+  /** Secondary label shown below the title, e.g. "Countries". */
+  subtitle: string;
+  /** All legend categories. */
+  legends: Legend[];
+  /** Region entries already filtered to this map type. */
+  entries: RegionEntry[];
+  /** testid applied to the section root for scoped test queries. */
+  testId: string;
+};
+
+/**
+ * One column in the stats modal — a donut chart plus per-legend counts for
+ * one map (world or US).
+ *
+ * @param props - Section labels, legends, and filtered region entries.
+ * @returns A section with a centered donut chart and a legend count list.
+ */
+const MapSection = ({
+  title,
+  subtitle,
+  legends,
+  entries,
+  testId,
+}: MapSectionProps): ReactElement => {
+  const countsByLegend: Record<string, number> = Object.fromEntries(legends.map((l) => [l.id, 0]));
+  for (const entry of entries) {
+    if (entry.legendId in countsByLegend) {
+      countsByLegend[entry.legendId]++;
+    }
+  }
+
+  const total = entries.length;
+  const segments: DonutSegment[] = legends.map((l) => ({
+    name: l.name,
+    color: l.color,
+    count: countsByLegend[l.id],
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col items-center gap-3" data-testid={testId}>
+      <DonutChart segments={segments} total={total} />
+      <div className="text-center">
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+      <ul className="w-full flex-col gap-1.5" aria-label={`${title} legend counts`}>
+        {legends.map((legend) => (
+          <li key={legend.id} className="flex items-center gap-2 py-0.5">
+            <span
+              className="h-4 w-4 shrink-0 rounded"
+              style={{ backgroundColor: legend.color }}
+              aria-hidden="true"
+            />
+            <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
+            <span className="tabular-nums text-sm text-muted-foreground">
+              {countsByLegend[legend.id]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+// ─── StatsModal ───────────────────────────────────────────────────────────────
+
+/**
+ * Header button that opens a stats modal breaking down how many regions have
+ * been assigned to each legend category, split between the world map and the
+ * US states map. Each section displays a hoverable donut chart with the total
+ * in the center.
+ *
+ * Reads directly from the Zustand store — no props needed. Region entries
+ * without a `world` field (saved before this field was introduced) are treated
+ * as world-map entries.
  *
  * @returns A ghost icon button that opens the stats dialog when clicked.
  */
@@ -35,13 +259,9 @@ export const StatsModal = (): ReactElement => {
   const assignedEntries = Object.values(regions).filter((r) => r.legendId);
   const total = assignedEntries.length;
 
-  /** Count of assigned regions per legend id. */
-  const countsByLegend: Record<string, number> = Object.fromEntries(legends.map((l) => [l.id, 0]));
-  for (const entry of assignedEntries) {
-    if (entry.legendId in countsByLegend) {
-      countsByLegend[entry.legendId] += 1;
-    }
-  }
+  // Entries without a `world` field default to the world map (backwards compat).
+  const worldEntries = assignedEntries.filter((r) => r.world !== false);
+  const usEntries = assignedEntries.filter((r) => r.world === false);
 
   const totalLabel =
     total === 0 ? "No regions marked yet." : `${total} region${total === 1 ? "" : "s"} marked`;
@@ -58,7 +278,7 @@ export const StatsModal = (): ReactElement => {
         <BarChart2 className="h-4 w-4" />
       </Button>
       <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Your Travels</DialogTitle>
             <DialogDescription>{totalLabel}</DialogDescription>
@@ -68,41 +288,22 @@ export const StatsModal = (): ReactElement => {
               No legend categories yet. Add some in the legend panel.
             </p>
           ) : (
-            <ul className="flex flex-col gap-3 pt-1">
-              {legends.map((legend) => {
-                const count = countsByLegend[legend.id];
-                const pct = total > 0 ? Math.round((count / total) * 100) : 0;
-
-                return (
-                  <li key={legend.id} className="flex items-center gap-3">
-                    <span
-                      className="h-4 w-4 shrink-0 rounded"
-                      style={{ backgroundColor: legend.color }}
-                      aria-hidden="true"
-                    />
-                    <span className="w-24 shrink-0 truncate text-sm text-foreground">
-                      {legend.name}
-                    </span>
-                    <div
-                      className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
-                      role="progressbar"
-                      aria-valuenow={pct}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                      aria-label={`${legend.name} progress`}
-                    >
-                      <div
-                        className="h-full rounded-full transition-all duration-300"
-                        style={{ width: `${pct}%`, backgroundColor: legend.color }}
-                      />
-                    </div>
-                    <span className="w-6 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
-                      {count}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
+            <div className="flex gap-6 pt-1">
+              <MapSection
+                title="World"
+                subtitle="Countries"
+                legends={legends}
+                entries={worldEntries}
+                testId="stats-world"
+              />
+              <MapSection
+                title="United States"
+                subtitle="States"
+                legends={legends}
+                entries={usEntries}
+                testId="stats-us"
+              />
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -182,10 +182,11 @@ export const useMapStore = create<MapStore>()((set, get) => {
     },
 
     assignRegion: (regionId, legendId) => {
-      const existing = get().regions[regionId];
+      const { world, regions: current } = get();
+      const existing = current[regionId];
       const regions = {
-        ...get().regions,
-        [regionId]: { legendId, note: existing?.note ?? "" },
+        ...current,
+        [regionId]: { legendId, note: existing?.note ?? "", world },
       };
       set({ regions });
       void saveState(snapshot());

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,11 @@ export type RegionEntry = {
   legendId: string;
   /** User note for this region, e.g. "Visited 2023". Empty string if none. */
   note: string;
+  /**
+   * Which map this region belongs to. True = world map, false = US map.
+   * Undefined on entries saved before this field was introduced — treated as world.
+   */
+  world?: boolean;
 };
 
 /** Full persisted state shape for the Zustand map store. */


### PR DESCRIPTION
## What changed
- Stats modal redesigned with two sections (World / Countries and United States / States), each showing a hoverable SVG donut chart — hovering a segment dims others and shows the category name and count in the center hole
- Region assignments now record which map they came from (`world` field on `RegionEntry`); legacy entries default to the world section
- Long country names in the region popup no longer truncate — the panel grows to fit

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->