### PR TITLE
fix(map): prevent zoom crash via Mercator clamping and error boundary

### DIFF
--- a/__tests__/components/MapErrorBoundary.test.tsx
+++ b/__tests__/components/MapErrorBoundary.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { MapErrorBoundary } from "@/components/MapErrorBoundary";
+
+/** Component that throws on render to simulate a map crash. */
+const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error("d3-geo null projection");
+  }
+  return <div data-testid="map-content">map ok</div>;
+};
+
+// Suppress React's console.error for expected errors in these tests.
+beforeEach(() => {
+  jest.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MapErrorBoundary", () => {
+  it("renders children when there is no error", () => {
+    render(
+      <MapErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </MapErrorBoundary>
+    );
+    expect(screen.getByTestId("map-content")).toBeInTheDocument();
+  });
+
+  it("shows an error message when the map crashes", () => {
+    render(
+      <MapErrorBoundary>
+        <Bomb shouldThrow />
+      </MapErrorBoundary>
+    );
+    expect(screen.getByText(/ran into a problem/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset view/i })).toBeInTheDocument();
+  });
+
+  it("recovers and remounts the map when Reset view is clicked", () => {
+    const { rerender } = render(
+      <MapErrorBoundary>
+        <Bomb shouldThrow />
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText(/ran into a problem/i)).toBeInTheDocument();
+
+    // Update children so they no longer throw before clicking reset,
+    // so the remount succeeds and shows the map content.
+    rerender(
+      <MapErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </MapErrorBoundary>
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reset view/i }));
+
+    expect(screen.getByTestId("map-content")).toBeInTheDocument();
+  });
+});

--- a/src/components/AmericaMap.tsx
+++ b/src/components/AmericaMap.tsx
@@ -79,7 +79,10 @@ export const AmericaMap = (): ReactElement => {
    * instance from being torn down and re-created on every render.
    */
   const handleMoveEnd = useCallback(({ coordinates, zoom: newZoom }: MoveEndResult) => {
-    setCenter(coordinates);
+    // Clamp to valid Mercator range — out-of-range coordinates cause d3-geo
+    // to return null from projection(), which crashes path rendering.
+    const [lon, lat] = coordinates;
+    setCenter([Math.max(-180, Math.min(180, lon)), Math.max(-85, Math.min(85, lat))]);
     setZoom(newZoom);
   }, []);
 

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -7,6 +7,7 @@
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 
+import { MapErrorBoundary } from "@/components/MapErrorBoundary";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMapStore } from "@/store/mapStore";
 
@@ -65,7 +66,7 @@ export const MapContainer = (): ReactElement => {
       className="flex h-full w-full items-center justify-center"
       style={{ backgroundColor: "var(--map-ocean)" }}
     >
-      {world ? <WorldMap /> : <AmericaMap />}
+      <MapErrorBoundary>{world ? <WorldMap /> : <AmericaMap />}</MapErrorBoundary>
     </div>
   );
 };

--- a/src/components/MapErrorBoundary.tsx
+++ b/src/components/MapErrorBoundary.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * Error boundary that catches crashes inside the map component (e.g. null
+ * projection results from d3-geo at extreme pan/zoom states) and recovers
+ * by resetting the map to its default view.
+ */
+
+import { Component } from "react";
+
+import type { ReactElement, ReactNode } from "react";
+
+/** Props for MapErrorBoundary. */
+type Props = {
+  /** The map component tree to protect. */
+  children: ReactNode;
+};
+
+/** State for MapErrorBoundary. */
+type State = {
+  /** Whether the boundary has caught an error. */
+  hasError: boolean;
+};
+
+/**
+ * Class-based error boundary wrapping the interactive map.
+ *
+ * When the map throws during render (e.g. a null pointer in d3-geo path
+ * generation at edge pan/zoom states), this boundary catches it, resets the
+ * view by unmounting and remounting the child tree via a key flip, and returns
+ * the user to the default zoom/center without losing their region data.
+ *
+ * @example
+ * <MapErrorBoundary><WorldMap /></MapErrorBoundary>
+ */
+export class MapErrorBoundary extends Component<Props, State> {
+  /** Monotonically increasing key used to force-remount the map on recovery. */
+  private resetKey = 0;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  private handleReset = (): void => {
+    this.resetKey += 1;
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactElement {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-3 text-muted-foreground">
+          <p className="text-sm">The map ran into a problem.</p>
+          <button
+            onClick={this.handleReset}
+            className="rounded-md bg-muted px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
+          >
+            Reset view
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div key={this.resetKey} className="h-full w-full">
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -75,7 +75,10 @@ export const WorldMap = (): ReactElement => {
    * instance from being torn down and re-created on every render.
    */
   const handleMoveEnd = useCallback(({ coordinates, zoom: newZoom }: MoveEndResult) => {
-    setCenter(coordinates);
+    // Clamp to valid Mercator range — out-of-range coordinates cause d3-geo
+    // to return null from projection(), which crashes path rendering.
+    const [lon, lat] = coordinates;
+    setCenter([Math.max(-180, Math.min(180, lon)), Math.max(-85, Math.min(85, lat))]);
     setZoom(newZoom);
   }, []);
 


### PR DESCRIPTION
## What changed
- Clamp longitude/latitude in \`handleMoveEnd\` to valid Mercator bounds (lon ±180, lat ±85) so d3-geo never receives out-of-range coordinates that cause \`projection()\` to return null and crash path rendering
- Added \`MapErrorBoundary\` around the map in \`MapContainer\` as a last-line safety net — if a crash slips through, users see "The map ran into a problem" with a Reset view button that remounts the map

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->