### PR TITLE
feat(stats): remove count list, keep donut chart only

### DIFF
--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -111,7 +111,7 @@ describe("StatsModal", () => {
     expect(screen.getByText("United States")).toBeInTheDocument();
   });
 
-  it("shows correct counts in the world section for regions without a world flag", async () => {
+  it("shows correct total in the world donut for regions without a world flag", async () => {
     setupStore([visited, driven], {
       "840": { legendId: "visited", note: "" },
       "250": { legendId: "visited", note: "" },
@@ -120,12 +120,10 @@ describe("StatsModal", () => {
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
     const worldSection = screen.getByTestId("stats-world");
-    const items = within(worldSection).getAllByRole("listitem");
-    expect(items[0]).toHaveTextContent("2");
-    expect(items[1]).toHaveTextContent("1");
+    expect(within(worldSection).getByText("3")).toBeInTheDocument();
   });
 
-  it("routes world=true entries to the world section and world=false to US", async () => {
+  it("routes world=true entries to the world donut and world=false to US donut", async () => {
     setupStore([visited], {
       "840": { legendId: "visited", note: "", world: true },
       "01": { legendId: "visited", note: "", world: false },
@@ -133,10 +131,8 @@ describe("StatsModal", () => {
     });
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
-    const worldSection = screen.getByTestId("stats-world");
-    const usSection = screen.getByTestId("stats-us");
-    expect(within(worldSection).getByRole("listitem")).toHaveTextContent("1");
-    expect(within(usSection).getByRole("listitem")).toHaveTextContent("2");
+    expect(within(screen.getByTestId("stats-world")).getByText("1")).toBeInTheDocument();
+    expect(within(screen.getByTestId("stats-us")).getByText("2")).toBeInTheDocument();
   });
 
   it("shows 'no categories yet' message when legend list is empty", async () => {
@@ -190,7 +186,7 @@ describe("StatsModal", () => {
     render(<StatsModal />);
     await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
     expect(screen.getByText(/2 regions marked/i)).toBeInTheDocument();
-    const worldSection = screen.getByTestId("stats-world");
-    expect(within(worldSection).getByRole("listitem")).toHaveTextContent("1");
+    // Only the valid legend (visited) produces a donut arc — deleted legend has no segment.
+    expect(screen.getByTestId("stats-world").querySelectorAll("path").length).toBe(1);
   });
 });

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -185,11 +185,12 @@ type MapSectionProps = {
 };
 
 /**
- * One column in the stats modal — a donut chart plus per-legend counts for
- * one map (world or US).
+ * One column in the stats modal — a donut chart for one map (world or US).
+ *
+ * Hovering an arc shows that category's count in the donut center.
  *
  * @param props - Section labels, legends, and filtered region entries.
- * @returns A section with a centered donut chart and a legend count list.
+ * @returns A section with a centered donut chart and title.
  */
 const MapSection = ({
   title,
@@ -219,21 +220,6 @@ const MapSection = ({
         <p className="text-sm font-semibold text-foreground">{title}</p>
         <p className="text-xs text-muted-foreground">{subtitle}</p>
       </div>
-      <ul className="w-full flex-col gap-1.5" aria-label={`${title} legend counts`}>
-        {legends.map((legend) => (
-          <li key={legend.id} className="flex items-center gap-2 py-0.5">
-            <span
-              className="h-4 w-4 shrink-0 rounded"
-              style={{ backgroundColor: legend.color }}
-              aria-hidden="true"
-            />
-            <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
-            <span className="tabular-nums text-sm text-muted-foreground">
-              {countsByLegend[legend.id]}
-            </span>
-          </li>
-        ))}
-      </ul>
     </div>
   );
 };
@@ -278,7 +264,7 @@ export const StatsModal = (): ReactElement => {
         <BarChart2 className="h-4 w-4" />
       </Button>
       <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-xs">
           <DialogHeader>
             <DialogTitle>Your Travels</DialogTitle>
             <DialogDescription>{totalLabel}</DialogDescription>


### PR DESCRIPTION
## What changed
- Removes the per-legend count list from each map section in the stats modal — the donut chart center already shows the total, making the list redundant
- Narrows the dialog from `sm:max-w-md` to `sm:max-w-xs` since the slimmer layout no longer needs the extra width
- Updates tests to assert on donut totals and arc counts instead of list items

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->