### PR TITLE
feat(legend): collapsible bottom drawer on mobile

### DIFF
--- a/__tests__/components/LegendPanel.test.tsx
+++ b/__tests__/components/LegendPanel.test.tsx
@@ -50,6 +50,22 @@ describe("LegendPanel", () => {
     expect(screen.getByRole("heading", { name: /legend/i })).toBeInTheDocument();
   });
 
+  it("renders the mobile toggle button", () => {
+    setupStore();
+    render(<LegendPanel />);
+    expect(screen.getByRole("button", { name: /open legend/i })).toBeInTheDocument();
+  });
+
+  it("toggles aria-expanded on the mobile strip button", async () => {
+    setupStore();
+    render(<LegendPanel />);
+    const toggle = screen.getByRole("button", { name: /open legend/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /close legend/i })).toBeInTheDocument();
+  });
+
   it("renders all legend category names", () => {
     setupStore();
     render(<LegendPanel />);

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -2,12 +2,17 @@
 
 /**
  * Sidebar panel listing legend categories with color swatches, inline edit, and remove buttons.
+ *
+ * On desktop (md+) it renders as a fixed left sidebar. On mobile it collapses
+ * to a 48px bottom strip showing color swatch previews; tapping the strip
+ * expands a scrollable drawer with the full legend list.
  */
 
-import { Check, Pencil, Trash2, X } from "lucide-react";
+import { Check, ChevronUp, Pencil, Trash2, X } from "lucide-react";
 import { useRef, useState } from "react";
 
 import { AddLegendModal } from "@/components/AddLegendModal";
+import { cn } from "@/lib/utils";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
@@ -16,7 +21,7 @@ import type { ReactElement } from "react";
 const iconBtn = "flex h-6 w-6 shrink-0 items-center justify-center transition-colors";
 
 /**
- * Sidebar panel showing all legend categories.
+ * Sidebar / bottom-drawer panel showing all legend categories.
  *
  * Each entry displays a color swatch and name. Clicking the pencil icon
  * enters inline edit mode: the swatch dot becomes a clickable button that
@@ -27,7 +32,8 @@ const iconBtn = "flex h-6 w-6 shrink-0 items-center justify-center transition-co
  * Only one row can be in edit or confirm mode at a time — entering either
  * state clears the other.
  *
- * @returns A `<aside>` sidebar listing legend items and an add-category trigger.
+ * @returns An `<aside>` that renders as a sidebar on desktop and a collapsible
+ *   bottom drawer on mobile.
  */
 export const LegendPanel = (): ReactElement => {
   const { legends, removeLegend, updateLegend } = useMapStore();
@@ -35,6 +41,7 @@ export const LegendPanel = (): ReactElement => {
   const [editId, setEditId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [editColor, setEditColor] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
 
   const startEdit = (id: string, name: string, color: string) => {
     setEditId(id);
@@ -55,124 +62,164 @@ export const LegendPanel = (): ReactElement => {
 
   return (
     <aside
-      className="flex w-full shrink-0 flex-row items-center gap-2 overflow-x-auto border-t border-border bg-surface p-3 md:w-56 md:flex-col md:items-stretch md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-t-0 md:p-4"
+      className={cn(
+        "flex w-full shrink-0 flex-col border-t border-border bg-surface",
+        "md:h-auto md:w-56 md:overflow-y-auto md:border-r md:border-t-0 md:p-4 md:gap-3",
+        isOpen ? "h-72" : "h-12"
+      )}
       data-screenshot="legend-panel"
     >
+      {/* Mobile toggle strip — hidden on desktop */}
+      <button
+        type="button"
+        className="flex h-12 shrink-0 items-center gap-2 px-3 md:hidden"
+        aria-label={isOpen ? "Close legend" : "Open legend"}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((v) => !v)}
+      >
+        <span className="text-sm font-semibold text-foreground">Legend</span>
+        <div className="flex flex-1 items-center gap-1.5 overflow-hidden" aria-hidden="true">
+          {legends.map((l) => (
+            <span
+              key={l.id}
+              className="h-3.5 w-3.5 shrink-0 rounded-full"
+              style={{ backgroundColor: l.color }}
+            />
+          ))}
+        </div>
+        <ChevronUp
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {/* Desktop sidebar heading */}
       <h2 className="hidden border-b border-border pb-2 text-base font-semibold text-foreground md:block">
         Legend
       </h2>
-      <ul className="flex flex-row items-center gap-2 md:flex-col md:items-stretch md:gap-1">
-        {legends.map((legend) => (
-          <li
-            key={legend.id}
-            className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-background/70"
-          >
-            {editId === legend.id ? (
-              <>
-                <input
-                  ref={colorInputRef}
-                  type="color"
-                  value={editColor}
-                  onChange={(e) => setEditColor(e.target.value)}
-                  className="sr-only"
-                  aria-label={`Color for ${legend.name}`}
-                  tabIndex={-1}
-                />
-                <button
-                  type="button"
-                  onClick={() => colorInputRef.current?.click()}
-                  className="h-5 w-5 shrink-0 cursor-pointer rounded ring-offset-1 hover:ring-2 hover:ring-border"
-                  style={{ backgroundColor: editColor }}
-                  aria-label={`Change color for ${legend.name}`}
-                />
-                <input
-                  type="text"
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      saveEdit(legend.id, legend.name);
-                    }
-                    if (e.key === "Escape") {
-                      cancelEdit();
-                    }
-                  }}
-                  className="min-w-0 flex-1 rounded border border-border bg-background px-1 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
-                  aria-label="Legend name"
-                  autoFocus
-                />
-                <button
-                  className={`${iconBtn} text-foreground hover:text-foreground/70`}
-                  onClick={() => saveEdit(legend.id, legend.name)}
-                  aria-label={`Save ${legend.name}`}
-                >
-                  <Check className="h-3 w-3" />
-                </button>
-                <button
-                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
-                  onClick={cancelEdit}
-                  aria-label="Cancel edit"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </>
-            ) : confirmId === legend.id ? (
-              <>
-                <span
-                  className="h-5 w-5 shrink-0 rounded"
-                  style={{ backgroundColor: legend.color }}
-                  aria-hidden="true"
-                />
-                <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
-                <button
-                  className={`${iconBtn} text-destructive hover:text-destructive/70`}
-                  onClick={() => {
-                    removeLegend(legend.id);
-                    setConfirmId(null);
-                  }}
-                  aria-label={`Confirm remove ${legend.name}`}
-                >
-                  <Check className="h-3 w-3" />
-                </button>
-                <button
-                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
-                  onClick={() => setConfirmId(null)}
-                  aria-label="Cancel"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </>
-            ) : (
-              <>
-                <span
-                  className="h-5 w-5 shrink-0 rounded"
-                  style={{ backgroundColor: legend.color }}
-                  aria-hidden="true"
-                />
-                <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
-                <button
-                  className={`${iconBtn} text-muted-foreground hover:text-foreground`}
-                  onClick={() => startEdit(legend.id, legend.name, legend.color)}
-                  aria-label={`Edit ${legend.name}`}
-                >
-                  <Pencil className="h-3 w-3" />
-                </button>
-                <button
-                  className={`${iconBtn} text-muted-foreground hover:text-destructive`}
-                  onClick={() => {
-                    setConfirmId(legend.id);
-                    setEditId(null);
-                  }}
-                  aria-label={`Remove ${legend.name}`}
-                >
-                  <Trash2 className="h-3 w-3" />
-                </button>
-              </>
-            )}
-          </li>
-        ))}
-      </ul>
-      <AddLegendModal />
+
+      {/* Scrollable content: always visible on desktop, toggled on mobile */}
+      <div
+        className={cn(
+          "flex flex-1 flex-col gap-2 overflow-y-auto px-3 pb-3 md:flex md:gap-1 md:p-0",
+          isOpen ? "flex" : "hidden md:flex"
+        )}
+      >
+        <ul className="flex flex-col gap-1">
+          {legends.map((legend) => (
+            <li
+              key={legend.id}
+              className="flex shrink-0 items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-background/70"
+            >
+              {editId === legend.id ? (
+                <>
+                  <input
+                    ref={colorInputRef}
+                    type="color"
+                    value={editColor}
+                    onChange={(e) => setEditColor(e.target.value)}
+                    className="sr-only"
+                    aria-label={`Color for ${legend.name}`}
+                    tabIndex={-1}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => colorInputRef.current?.click()}
+                    className="h-5 w-5 shrink-0 cursor-pointer rounded ring-offset-1 hover:ring-2 hover:ring-border"
+                    style={{ backgroundColor: editColor }}
+                    aria-label={`Change color for ${legend.name}`}
+                  />
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        saveEdit(legend.id, legend.name);
+                      }
+                      if (e.key === "Escape") {
+                        cancelEdit();
+                      }
+                    }}
+                    className="min-w-0 flex-1 rounded border border-border bg-background px-1 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+                    aria-label="Legend name"
+                    autoFocus
+                  />
+                  <button
+                    className={`${iconBtn} text-foreground hover:text-foreground/70`}
+                    onClick={() => saveEdit(legend.id, legend.name)}
+                    aria-label={`Save ${legend.name}`}
+                  >
+                    <Check className="h-3 w-3" />
+                  </button>
+                  <button
+                    className={`${iconBtn} text-muted-foreground hover:text-foreground`}
+                    onClick={cancelEdit}
+                    aria-label="Cancel edit"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </>
+              ) : confirmId === legend.id ? (
+                <>
+                  <span
+                    className="h-5 w-5 shrink-0 rounded"
+                    style={{ backgroundColor: legend.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 truncate text-xs text-destructive">Remove?</span>
+                  <button
+                    className={`${iconBtn} text-destructive hover:text-destructive/70`}
+                    onClick={() => {
+                      removeLegend(legend.id);
+                      setConfirmId(null);
+                    }}
+                    aria-label={`Confirm remove ${legend.name}`}
+                  >
+                    <Check className="h-3 w-3" />
+                  </button>
+                  <button
+                    className={`${iconBtn} text-muted-foreground hover:text-foreground`}
+                    onClick={() => setConfirmId(null)}
+                    aria-label="Cancel"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <span
+                    className="h-5 w-5 shrink-0 rounded"
+                    style={{ backgroundColor: legend.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 truncate text-sm text-foreground">{legend.name}</span>
+                  <button
+                    className={`${iconBtn} text-muted-foreground hover:text-foreground`}
+                    onClick={() => startEdit(legend.id, legend.name, legend.color)}
+                    aria-label={`Edit ${legend.name}`}
+                  >
+                    <Pencil className="h-3 w-3" />
+                  </button>
+                  <button
+                    className={`${iconBtn} text-muted-foreground hover:text-destructive`}
+                    onClick={() => {
+                      setConfirmId(legend.id);
+                      setEditId(null);
+                    }}
+                    aria-label={`Remove ${legend.name}`}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+        <AddLegendModal />
+      </div>
     </aside>
   );
 };


### PR DESCRIPTION
## What changed
- Replaces the horizontal scroll strip on mobile with a 48px collapsed bar showing color swatch dots and a chevron; tapping it slides up a 288px vertical drawer with the full legend list and add button
- Fixes the color picker going off-screen during inline edit: with a vertical layout and more height, the native color picker dialog has room to open
- Desktop sidebar layout is unchanged

## Screenshots
<!-- screenshots-start -->
### legend-panel

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr36-before-legend-panel-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr36-after-legend-panel-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr36-before-legend-panel-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr36-after-legend-panel-dark.png) |
<!-- screenshots-end -->