### PR TITLE
feat(stats): progress bars showing regions marked out of total possible

### DIFF
--- a/__tests__/components/StatsModal.test.tsx
+++ b/__tests__/components/StatsModal.test.tsx
@@ -151,6 +151,48 @@ describe("StatsModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("shows the world progress bar with correct fraction text", async () => {
+    setupStore([visited], {
+      "840": { legendId: "visited", note: "", world: true },
+      "250": { legendId: "visited", note: "", world: true },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    const worldSection = screen.getByTestId("stats-world");
+    expect(within(worldSection).getByText("2 / 195")).toBeInTheDocument();
+  });
+
+  it("shows the US progress bar with correct fraction text", async () => {
+    setupStore([visited], {
+      "01": { legendId: "visited", note: "", world: false },
+      "48": { legendId: "visited", note: "", world: false },
+      "06": { legendId: "visited", note: "", world: false },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    const usSection = screen.getByTestId("stats-us");
+    expect(within(usSection).getByText("3 / 50")).toBeInTheDocument();
+  });
+
+  it("shows 0 / 195 and 0 / 50 when nothing is assigned", async () => {
+    setupStore([visited], {});
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    expect(within(screen.getByTestId("stats-world")).getByText("0 / 195")).toBeInTheDocument();
+    expect(within(screen.getByTestId("stats-us")).getByText("0 / 50")).toBeInTheDocument();
+  });
+
+  it("renders the world progress bar with the correct aria attributes", async () => {
+    setupStore([visited], {
+      "840": { legendId: "visited", note: "", world: true },
+    });
+    render(<StatsModal />);
+    await userEvent.click(screen.getByRole("button", { name: /view stats/i }));
+    const bar = within(screen.getByTestId("stats-world")).getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "1");
+    expect(bar).toHaveAttribute("aria-valuemax", "195");
+  });
+
   it("ignores regions with no legendId when counting totals", async () => {
     setupStore([visited], {
       "840": { legendId: "visited", note: "" },

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -162,7 +162,7 @@ const DonutChart = ({ segments, total }: DonutChartProps): ReactElement => {
           fontFamily: "var(--font-heading)",
         }}
       >
-        {hovered?.name ?? "total"}
+        {hovered?.name ?? "Total"}
       </text>
     </svg>
   );

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -234,7 +234,7 @@ const MapSection = ({
         <p className="text-sm font-semibold text-foreground">{title}</p>
         <p className="text-xs text-muted-foreground">{subtitle}</p>
         <div
-          className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+          className="h-1.5 w-full overflow-hidden rounded-full bg-secondary"
           role="progressbar"
           aria-valuenow={total}
           aria-valuemin={0}
@@ -242,7 +242,7 @@ const MapSection = ({
           aria-label={`${total} of ${mapTotal} ${subtitle.toLowerCase()} marked`}
         >
           <div
-            className="h-full rounded-full bg-foreground/50 transition-[width] duration-300"
+            className="h-full rounded-full bg-primary transition-[width] duration-300"
             style={{ width: `${progressPct}%` }}
           />
         </div>

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -170,6 +170,12 @@ const DonutChart = ({ segments, total }: DonutChartProps): ReactElement => {
 
 // ─── Map section ─────────────────────────────────────────────────────────────
 
+/** Total number of UN-recognized sovereign states tracked in the world map. */
+const WORLD_TOTAL = 195;
+
+/** Total number of US states tracked in the US map. */
+const US_TOTAL = 50;
+
 /** Props for MapSection. */
 type MapSectionProps = {
   /** Primary label for the section, e.g. "World". */
@@ -180,23 +186,29 @@ type MapSectionProps = {
   legends: Legend[];
   /** Region entries already filtered to this map type. */
   entries: RegionEntry[];
+  /** Total possible regions in this map, used to render the progress bar. */
+  mapTotal: number;
   /** testid applied to the section root for scoped test queries. */
   testId: string;
 };
 
 /**
- * One column in the stats modal — a donut chart for one map (world or US).
+ * One column in the stats modal — a donut chart and progress bar for one map
+ * (world or US).
  *
- * Hovering an arc shows that category's count in the donut center.
+ * Hovering an arc shows that category's count in the donut center. The slim
+ * progress bar below the title shows how many regions have been marked out of
+ * the total possible for this map.
  *
- * @param props - Section labels, legends, and filtered region entries.
- * @returns A section with a centered donut chart and title.
+ * @param props - Section labels, legends, filtered region entries, and map total.
+ * @returns A section with a donut chart, title, and progress bar.
  */
 const MapSection = ({
   title,
   subtitle,
   legends,
   entries,
+  mapTotal,
   testId,
 }: MapSectionProps): ReactElement => {
   const countsByLegend: Record<string, number> = Object.fromEntries(legends.map((l) => [l.id, 0]));
@@ -213,12 +225,30 @@ const MapSection = ({
     count: countsByLegend[l.id],
   }));
 
+  const progressPct = Math.min(100, (total / mapTotal) * 100);
+
   return (
     <div className="flex flex-1 flex-col items-center gap-3" data-testid={testId}>
       <DonutChart segments={segments} total={total} />
-      <div className="text-center">
+      <div className="w-full space-y-1.5 text-center">
         <p className="text-sm font-semibold text-foreground">{title}</p>
         <p className="text-xs text-muted-foreground">{subtitle}</p>
+        <div
+          className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+          role="progressbar"
+          aria-valuenow={total}
+          aria-valuemin={0}
+          aria-valuemax={mapTotal}
+          aria-label={`${total} of ${mapTotal} ${subtitle.toLowerCase()} marked`}
+        >
+          <div
+            className="h-full rounded-full bg-foreground/50 transition-[width] duration-300"
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+        <p className="text-xs tabular-nums text-muted-foreground">
+          {total} / {mapTotal}
+        </p>
       </div>
     </div>
   );
@@ -280,6 +310,7 @@ export const StatsModal = (): ReactElement => {
                 subtitle="Countries"
                 legends={legends}
                 entries={worldEntries}
+                mapTotal={WORLD_TOTAL}
                 testId="stats-world"
               />
               <MapSection
@@ -287,6 +318,7 @@ export const StatsModal = (): ReactElement => {
                 subtitle="States"
                 legends={legends}
                 entries={usEntries}
+                mapTotal={US_TOTAL}
                 testId="stats-us"
               />
             </div>

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -234,7 +234,7 @@ const MapSection = ({
         <p className="text-sm font-semibold text-foreground">{title}</p>
         <p className="text-xs text-muted-foreground">{subtitle}</p>
         <div
-          className="h-1.5 w-full overflow-hidden rounded-full bg-secondary"
+          className="h-2 w-full overflow-hidden rounded-full bg-foreground/10"
           role="progressbar"
           aria-valuenow={total}
           aria-valuemin={0}


### PR DESCRIPTION
## What changed
- Adds a slim progress bar and fraction counter (e.g. "42 / 195") below each donut chart in the stats modal, so users can see how far along they are toward covering all countries (195) or US states (50)
- Progress bar uses `role="progressbar"` with proper aria attributes for accessibility

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->