### PR TITLE
feat(share): add share to socials and map import from URL

### DIFF
--- a/__tests__/components/AppShell.test.tsx
+++ b/__tests__/components/AppShell.test.tsx
@@ -13,6 +13,9 @@ jest.mock("@/components/Header", () => ({
 jest.mock("@/components/LegendPanel", () => ({
   LegendPanel: () => <div data-testid="legend-panel" />,
 }));
+jest.mock("@/components/ShareImportDialog", () => ({
+  ShareImportDialog: () => null,
+}));
 
 const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore> & {
   getState: jest.Mock;

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -54,11 +54,13 @@ const setupStore = (world = true) => {
     regions: {},
     addLegend: jest.fn(),
     removeLegend: jest.fn(),
+    updateLegend: jest.fn(),
     assignRegion: jest.fn(),
     unassignRegion: jest.fn(),
     setRegionNote: jest.fn(),
     clearData,
     hydrate: jest.fn().mockResolvedValue(undefined),
+    importState: jest.fn(),
   } as ReturnType<typeof useMapStore>);
   return { setWorld, clearData };
 };

--- a/__tests__/components/ShareImportDialog.test.tsx
+++ b/__tests__/components/ShareImportDialog.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useSearchParams } from "next/navigation";
+
+import { ShareImportDialog } from "@/components/ShareImportDialog";
+import { encodeState } from "@/lib/share";
+import { useMapStore } from "@/store/mapStore";
+
+import { createMapState } from "../factories/createMapState";
+
+jest.mock("@/store/mapStore");
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div>{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogAction: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  AlertDialogCancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+const mockUseSearchParams = useSearchParams as jest.MockedFunction<typeof useSearchParams>;
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const sharedState = createMapState({ world: false });
+const validEncoded = encodeState(sharedState);
+
+const setupStore = () => {
+  const importState = jest.fn();
+  mockUseMapStore.mockReturnValue({
+    ...createMapState(),
+    setWorld: jest.fn(),
+    addLegend: jest.fn(),
+    removeLegend: jest.fn(),
+    updateLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn(),
+    importState,
+  } as ReturnType<typeof useMapStore>);
+  return { importState };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ShareImportDialog", () => {
+  it("renders nothing when the s param is absent", () => {
+    setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams() as ReturnType<typeof useSearchParams>
+    );
+    const { container } = render(<ShareImportDialog />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the s param is invalid base64", () => {
+    setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams("s=not-valid-encoded-state") as ReturnType<typeof useSearchParams>
+    );
+    const { container } = render(<ShareImportDialog />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the import dialog when a valid s param is present", () => {
+    setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`s=${validEncoded}`) as ReturnType<typeof useSearchParams>
+    );
+    render(<ShareImportDialog />);
+    expect(screen.getByRole("heading", { name: /import shared map\?/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /import map/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /keep my map/i })).toBeInTheDocument();
+  });
+
+  it("calls importState with the decoded state when Import map is clicked", async () => {
+    const { importState } = setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`s=${validEncoded}`) as ReturnType<typeof useSearchParams>
+    );
+    render(<ShareImportDialog />);
+    await userEvent.click(screen.getByRole("button", { name: /import map/i }));
+    expect(importState).toHaveBeenCalledWith(sharedState);
+  });
+
+  it("dismisses the dialog when Keep my map is clicked without importing", async () => {
+    const { importState } = setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`s=${validEncoded}`) as ReturnType<typeof useSearchParams>
+    );
+    render(<ShareImportDialog />);
+    await userEvent.click(screen.getByRole("button", { name: /keep my map/i }));
+    expect(importState).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("dismisses the dialog after importing", async () => {
+    setupStore();
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`s=${validEncoded}`) as ReturnType<typeof useSearchParams>
+    );
+    render(<ShareImportDialog />);
+    await userEvent.click(screen.getByRole("button", { name: /import map/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/ShareModal.test.tsx
+++ b/__tests__/components/ShareModal.test.tsx
@@ -8,6 +8,15 @@ import { createMapState } from "../factories/createMapState";
 
 jest.mock("@/store/mapStore");
 
+jest.mock("@icons-pack/react-simple-icons", () => ({
+  SiBluesky: () => <svg data-testid="icon-bluesky" />,
+  SiBlueskyHex: "#0085ff",
+  SiFacebook: () => <svg data-testid="icon-facebook" />,
+  SiFacebookHex: "#0866FF",
+  SiReddit: () => <svg data-testid="icon-reddit" />,
+  SiRedditHex: "#FF4500",
+}));
+
 jest.mock("@/components/ui/dialog", () => ({
   Dialog: ({
     children,
@@ -57,20 +66,57 @@ describe("ShareModal", () => {
     expect(screen.getByRole("button", { name: /share map/i })).toBeInTheDocument();
   });
 
-  it("shows the share dialog with Twitter and Copy link buttons", () => {
+  it("shows the share dialog with all platform buttons", () => {
     setupStore();
     render(<ShareModal />);
     expect(screen.getByRole("heading", { name: /share your map/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /share on twitter/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share on facebook/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share on reddit/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share on bluesky/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share on sms/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /copy link/i })).toBeInTheDocument();
   });
 
-  it("opens a Twitter intent URL in a new tab when Twitter is clicked", async () => {
+  it("opens a Twitter intent URL when Twitter is clicked", async () => {
     setupStore();
     render(<ShareModal />);
     await userEvent.click(screen.getByRole("button", { name: /share on twitter/i }));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringContaining("twitter.com/intent/tweet"),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens a Facebook sharer URL when Facebook is clicked", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /share on facebook/i }));
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("facebook.com/sharer"),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens a Reddit submit URL when Reddit is clicked", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /share on reddit/i }));
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("reddit.com/submit"),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens a Bluesky compose URL when Bluesky is clicked", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /share on bluesky/i }));
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("bsky.app/intent/compose"),
       "_blank",
       "noopener,noreferrer"
     );
@@ -90,8 +136,7 @@ describe("ShareModal", () => {
     expect(screen.getByRole("button", { name: /copied!/i })).toBeInTheDocument();
   });
 
-  it("shows a too-long message when the encoded state exceeds the URL limit", () => {
-    // Create a state with many large notes to force an oversized URL.
+  it("shows a too-long message and hides share options when state exceeds URL limit", () => {
     const regions: Record<string, { legendId: string; note: string }> = {};
     for (let i = 0; i < 50; i++) {
       regions[`region-${i}`] = { legendId: "visited", note: "x".repeat(100) };

--- a/__tests__/components/ShareModal.test.tsx
+++ b/__tests__/components/ShareModal.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ShareModal } from "@/components/ShareModal";
+import { useMapStore } from "@/store/mapStore";
+
+import { createMapState } from "../factories/createMapState";
+
+jest.mock("@/store/mapStore");
+
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (v: boolean) => void;
+  }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+const mockUseMapStore = useMapStore as jest.MockedFunction<typeof useMapStore>;
+
+const setupStore = (state = createMapState()) => {
+  mockUseMapStore.mockReturnValue({
+    ...state,
+    setWorld: jest.fn(),
+    addLegend: jest.fn(),
+    removeLegend: jest.fn(),
+    updateLegend: jest.fn(),
+    assignRegion: jest.fn(),
+    unassignRegion: jest.fn(),
+    setRegionNote: jest.fn(),
+    clearData: jest.fn(),
+    hydrate: jest.fn(),
+    importState: jest.fn(),
+  } as ReturnType<typeof useMapStore>);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
+  jest.spyOn(window, "open").mockImplementation(() => null);
+});
+
+describe("ShareModal", () => {
+  it("renders a share button with an accessible label", () => {
+    setupStore();
+    render(<ShareModal />);
+    expect(screen.getByRole("button", { name: /share map/i })).toBeInTheDocument();
+  });
+
+  it("shows the share dialog with Twitter and Copy link buttons", () => {
+    setupStore();
+    render(<ShareModal />);
+    expect(screen.getByRole("heading", { name: /share your map/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /share on twitter/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy link/i })).toBeInTheDocument();
+  });
+
+  it("opens a Twitter intent URL in a new tab when Twitter is clicked", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /share on twitter/i }));
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("twitter.com/intent/tweet"),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("copies the share URL to the clipboard when Copy link is clicked", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /copy link/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining("/?s="));
+  });
+
+  it("shows Copied! feedback after copying", async () => {
+    setupStore();
+    render(<ShareModal />);
+    await userEvent.click(screen.getByRole("button", { name: /copy link/i }));
+    expect(screen.getByRole("button", { name: /copied!/i })).toBeInTheDocument();
+  });
+
+  it("shows a too-long message when the encoded state exceeds the URL limit", () => {
+    // Create a state with many large notes to force an oversized URL.
+    const regions: Record<string, { legendId: string; note: string }> = {};
+    for (let i = 0; i < 50; i++) {
+      regions[`region-${i}`] = { legendId: "visited", note: "x".repeat(100) };
+    }
+    setupStore(createMapState({ regions }));
+    render(<ShareModal />);
+    expect(screen.getByText(/too many notes/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /share on twitter/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy link/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/store/mapStore.test.ts
+++ b/__tests__/store/mapStore.test.ts
@@ -372,3 +372,31 @@ describe("hydrate", () => {
     expect(useMapStore.getState().legends).toEqual(before.legends);
   });
 });
+
+describe("importState", () => {
+  it("replaces all map state with the incoming snapshot", () => {
+    const incoming = {
+      world: false,
+      legends: [createLegend({ id: "camped", name: "Camped", color: "#7c3aed" })],
+      regions: { "US-CA": { legendId: "camped", note: "summer trip" } },
+    };
+    act(() => {
+      useMapStore.getState().importState(incoming);
+    });
+    expect(useMapStore.getState().world).toBe(false);
+    expect(useMapStore.getState().legends).toEqual(incoming.legends);
+    expect(useMapStore.getState().regions).toEqual(incoming.regions);
+  });
+
+  it("persists the imported state to storage", () => {
+    const incoming = {
+      world: false,
+      legends: [createLegend()],
+      regions: {},
+    };
+    act(() => {
+      useMapStore.getState().importState(incoming);
+    });
+    expect(mockSaveState).toHaveBeenCalledWith(incoming);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@icons-pack/react-simple-icons": "^13.13.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@icons-pack/react-simple-icons':
+        specifier: ^13.13.0
+        version: 13.13.0(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -497,6 +500,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@icons-pack/react-simple-icons@13.13.0':
+    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
+    engines: {node: '>=24', pnpm: '>=10'}
+    peerDependencies:
+      react: ^16.13 || ^17 || ^18 || ^19
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4720,6 +4729,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@icons-pack/react-simple-icons@13.13.0(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
 
   '@img/colour@1.1.0':
     optional: true

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,11 +4,12 @@
  * Root client component: hydrates persisted map state and renders the full app layout.
  */
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 
 import { Header } from "@/components/Header";
 import { LegendPanel } from "@/components/LegendPanel";
 import { MapContainer } from "@/components/MapContainer";
+import { ShareImportDialog } from "@/components/ShareImportDialog";
 import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
@@ -17,8 +18,9 @@ import type { ReactElement } from "react";
  * Client-side app shell that loads persisted map state from storage on mount
  * and renders the full app layout (header, legend panel, map).
  *
- * The IndexedDB hydration runs in useEffect to avoid server/client mismatches:
- * storage APIs are browser-only.
+ * Hydration runs in useEffect to avoid server/client mismatches: storage APIs
+ * are browser-only. ShareImportDialog is wrapped in Suspense because it calls
+ * useSearchParams(), which requires a boundary.
  *
  * @returns The full app layout.
  */
@@ -30,6 +32,9 @@ export const AppShell = (): ReactElement => {
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <Header />
+      <Suspense>
+        <ShareImportDialog />
+      </Suspense>
       <div className="flex flex-1 flex-col-reverse overflow-hidden md:flex-row">
         <LegendPanel />
         <main className="min-h-0 flex-1 overflow-hidden">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { DarkModeToggle } from "@/components/DarkModeToggle";
+import { ShareModal } from "@/components/ShareModal";
 import { StatsModal } from "@/components/StatsModal";
 import {
   AlertDialog,
@@ -31,6 +32,7 @@ import type { ReactElement } from "react";
  * - App title using the Fraunces heading font
  * - World / United States map toggle buttons
  * - Stats modal button showing per-legend region counts
+ * - Share button that opens a dialog with Twitter and copy-link options
  * - Clear-data button that opens a confirmation dialog before wiping all state
  * - Dark mode toggle
  *
@@ -84,6 +86,7 @@ export const Header = (): ReactElement => {
       </div>
       <div className="flex items-center gap-1">
         <StatsModal />
+        <ShareModal />
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/ShareImportDialog.tsx
+++ b/src/components/ShareImportDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Dialog shown when the user opens a share URL containing encoded map state.
+ *
+ * Reads the `s` query parameter on mount and, if it decodes to a valid MapState,
+ * prompts the user to import or dismiss. This component must be wrapped in a
+ * React Suspense boundary because it calls useSearchParams().
+ */
+
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { decodeState } from "@/lib/share";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/**
+ * Reads the `s` query parameter and shows an import confirmation dialog when
+ * a valid encoded MapState is present. Returns null if the param is absent,
+ * invalid, or the user has already dismissed the dialog.
+ *
+ * @returns An AlertDialog prompting the user to import or keep their map, or null.
+ */
+export const ShareImportDialog = (): ReactElement | null => {
+  const searchParams = useSearchParams();
+  const encoded = searchParams.get("s");
+  const sharedState = encoded ? decodeState(encoded) : null;
+
+  const [dismissed, setDismissed] = useState(false);
+  const { importState } = useMapStore();
+
+  if (!sharedState || dismissed) {
+    return null;
+  }
+
+  const handleImport = (): void => {
+    importState(sharedState);
+    setDismissed(true);
+  };
+
+  const handleDismiss = (): void => {
+    setDismissed(true);
+  };
+
+  return (
+    <AlertDialog open>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Import shared map?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will replace your current map data with the shared snapshot. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleDismiss}>Keep my map</AlertDialogCancel>
+          <AlertDialogAction onClick={handleImport}>Import map</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -37,20 +37,18 @@ export const ShareModal = (): ReactElement => {
   const encoded = encodeState({ world, legends, regions });
   const tooLong = isShareUrlTooLong(encoded);
 
-  /**
-   * Builds the full share URL using the current origin so it works across
-   * local dev, preview, and production environments.
-   */
-  const shareUrl = `${window.location.origin}/?s=${encoded}`;
+  /** Builds the share URL at call-time so window is only accessed client-side. */
+  const buildShareUrl = (): string => `${window.location.origin}/?s=${encoded}`;
 
   const handleCopy = async (): Promise<void> => {
-    await navigator.clipboard.writeText(shareUrl);
+    await navigator.clipboard.writeText(buildShareUrl());
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   const handleTwitter = (): void => {
-    const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent("Check out my travel map!")}&url=${encodeURIComponent(shareUrl)}`;
+    const url = buildShareUrl();
+    const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent("Check out my travel map!")}&url=${encodeURIComponent(url)}`;
     window.open(tweetUrl, "_blank", "noopener,noreferrer");
   };
 

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * Share button and dialog for generating a shareable snapshot URL.
+ */
+
+import { Bird, Check, Link2, Share2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { encodeState, isShareUrlTooLong } from "@/lib/share";
+import { useMapStore } from "@/store/mapStore";
+
+import type { ReactElement } from "react";
+
+/**
+ * A ghost icon button that opens a share dialog with Twitter and copy-link options.
+ *
+ * The share URL encodes the current MapState as URL-safe base64 in the `s` query
+ * parameter. If the encoded state exceeds the URL length limit, both share options
+ * are replaced with a friendly "too long" message.
+ *
+ * @returns A dialog-triggering button rendered as a Share2 icon.
+ */
+export const ShareModal = (): ReactElement => {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const { world, legends, regions } = useMapStore();
+
+  const encoded = encodeState({ world, legends, regions });
+  const tooLong = isShareUrlTooLong(encoded);
+
+  /**
+   * Builds the full share URL using the current origin so it works across
+   * local dev, preview, and production environments.
+   */
+  const shareUrl = `${window.location.origin}/?s=${encoded}`;
+
+  const handleCopy = async (): Promise<void> => {
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleTwitter = (): void => {
+    const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent("Check out my travel map!")}&url=${encodeURIComponent(shareUrl)}`;
+    window.open(tweetUrl, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground"
+        aria-label="Share map"
+        onClick={() => setOpen(true)}
+      >
+        <Share2 className="h-4 w-4" aria-hidden="true" />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Share your map</DialogTitle>
+            <DialogDescription>
+              {tooLong
+                ? "Your map has too many notes to share as a URL. Try removing some notes and sharing again."
+                : "Anyone with this link can view a snapshot of your current map."}
+            </DialogDescription>
+          </DialogHeader>
+          {!tooLong && (
+            <div className="flex flex-col gap-3">
+              <Button
+                variant="outline"
+                className="w-full justify-start gap-2"
+                onClick={handleTwitter}
+              >
+                <Bird className="h-4 w-4" aria-hidden="true" />
+                Share on Twitter
+              </Button>
+              <Button variant="outline" className="w-full justify-start gap-2" onClick={handleCopy}>
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-600" aria-hidden="true" />
+                ) : (
+                  <Link2 className="h-4 w-4" aria-hidden="true" />
+                )}
+                {copied ? "Copied!" : "Copy link"}
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 /**
- * Share button and dialog for generating a shareable snapshot URL.
+ * Share button and dialog for sharing a map snapshot to social platforms.
  */
 
-import { Bird, Check, Link2, Share2 } from "lucide-react";
+import {
+  SiBluesky,
+  SiBlueskyHex,
+  SiFacebook,
+  SiFacebookHex,
+  SiReddit,
+  SiRedditHex,
+} from "@icons-pack/react-simple-icons";
+import { Bird, Check, Link2, MessageSquare, Share2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -20,14 +28,18 @@ import { useMapStore } from "@/store/mapStore";
 
 import type { ReactElement } from "react";
 
+/** Twitter's brand blue, kept locally since simple-icons dropped the Twitter bird in favor of X. */
+const TWITTER_BLUE = "#1D9BF0";
+
 /**
- * A ghost icon button that opens a share dialog with Twitter and copy-link options.
+ * A ghost icon button that opens a share dialog with platform and copy-link options.
  *
- * The share URL encodes the current MapState as URL-safe base64 in the `s` query
- * parameter. If the encoded state exceeds the URL length limit, both share options
- * are replaced with a friendly "too long" message.
+ * Platforms: Twitter (bird), Facebook, Reddit, Bluesky, SMS.
+ * The share URL encodes the current MapState as URL-safe base64 in the `s` query parameter.
+ * If the encoded state exceeds the URL length limit, share options are replaced with
+ * a friendly "too long" message.
  *
- * @returns A dialog-triggering button rendered as a Share2 icon.
+ * @returns A button that opens the share dialog.
  */
 export const ShareModal = (): ReactElement => {
   const [open, setOpen] = useState(false);
@@ -46,10 +58,40 @@ export const ShareModal = (): ReactElement => {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const openShare = (url: string): void => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
   const handleTwitter = (): void => {
     const url = buildShareUrl();
-    const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent("Check out my travel map!")}&url=${encodeURIComponent(url)}`;
-    window.open(tweetUrl, "_blank", "noopener,noreferrer");
+    openShare(
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent("Check out my travel map!")}&url=${encodeURIComponent(url)}`
+    );
+  };
+
+  const handleFacebook = (): void => {
+    openShare(
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(buildShareUrl())}`
+    );
+  };
+
+  const handleReddit = (): void => {
+    const url = buildShareUrl();
+    openShare(
+      `https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent("My travel map")}`
+    );
+  };
+
+  const handleBluesky = (): void => {
+    const url = buildShareUrl();
+    openShare(
+      `https://bsky.app/intent/compose?text=${encodeURIComponent(`Check out my travel map! ${url}`)}`
+    );
+  };
+
+  const handleSms = (): void => {
+    const url = buildShareUrl();
+    window.location.href = `sms:?body=${encodeURIComponent(`Check out my travel map! ${url}`)}`;
   };
 
   return (
@@ -74,16 +116,29 @@ export const ShareModal = (): ReactElement => {
             </DialogDescription>
           </DialogHeader>
           {!tooLong && (
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-5 gap-2">
+                <PlatformButton label="Twitter" onClick={handleTwitter}>
+                  <Bird className="h-5 w-5" style={{ color: TWITTER_BLUE }} aria-hidden="true" />
+                </PlatformButton>
+                <PlatformButton label="Facebook" onClick={handleFacebook}>
+                  <SiFacebook className="h-5 w-5" color={SiFacebookHex} aria-hidden="true" />
+                </PlatformButton>
+                <PlatformButton label="Reddit" onClick={handleReddit}>
+                  <SiReddit className="h-5 w-5" color={SiRedditHex} aria-hidden="true" />
+                </PlatformButton>
+                <PlatformButton label="Bluesky" onClick={handleBluesky}>
+                  <SiBluesky className="h-5 w-5" color={SiBlueskyHex} aria-hidden="true" />
+                </PlatformButton>
+                <PlatformButton label="SMS" onClick={handleSms}>
+                  <MessageSquare className="h-5 w-5 text-green-500" aria-hidden="true" />
+                </PlatformButton>
+              </div>
               <Button
                 variant="outline"
-                className="w-full justify-start gap-2"
-                onClick={handleTwitter}
+                className="w-full justify-center gap-2"
+                onClick={handleCopy}
               >
-                <Bird className="h-4 w-4" aria-hidden="true" />
-                Share on Twitter
-              </Button>
-              <Button variant="outline" className="w-full justify-start gap-2" onClick={handleCopy}>
                 {copied ? (
                   <Check className="h-4 w-4 text-green-600" aria-hidden="true" />
                 ) : (
@@ -98,3 +153,29 @@ export const ShareModal = (): ReactElement => {
     </>
   );
 };
+
+type PlatformButtonProps = {
+  /** Platform name shown as a label below the icon. */
+  label: string;
+  /** Click handler for the platform share action. */
+  onClick: () => void;
+  /** Brand icon for the platform. */
+  children: React.ReactNode;
+};
+
+/**
+ * A compact square button showing a brand icon and platform label.
+ *
+ * @param props - Label, click handler, and icon.
+ * @returns A bordered button card.
+ */
+const PlatformButton = ({ label, onClick, children }: PlatformButtonProps): ReactElement => (
+  <button
+    onClick={onClick}
+    className="flex flex-col items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    aria-label={`Share on ${label}`}
+  >
+    {children}
+    {label}
+  </button>
+);

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -120,6 +120,17 @@ export type MapStore = MapState & {
    * useEffect(() => { useMapStore.getState().hydrate(); }, []);
    */
   hydrate: () => void;
+
+  /**
+   * Replaces the entire map state with an incoming shared snapshot and persists it.
+   * Used when the user accepts a shared map URL import.
+   *
+   * @param state - The decoded MapState from a share URL.
+   * @example
+   * const decoded = decodeState(encoded);
+   * if (decoded) store.importState(decoded);
+   */
+  importState: (state: MapState) => void;
 };
 
 /**
@@ -226,6 +237,11 @@ export const useMapStore = create<MapStore>()((set, get) => {
       if (saved) {
         set(saved);
       }
+    },
+
+    importState: (state) => {
+      set(state);
+      saveState(state);
     },
   };
 });


### PR DESCRIPTION
## What changed
- **ShareModal**: Share2 icon button in header opens a dialog with "Share on Twitter" (Bird icon, not X) and "Copy link" options; encodes the full MapState as URL-safe base64 in the `s` query param
- **ShareImportDialog**: detects a `?s=` param on load and prompts the user to import the shared snapshot or keep their own map; wrapped in Suspense because it uses `useSearchParams()`
- **`importState` store action**: replaces all map state with an incoming snapshot and persists it to localStorage immediately

## Screenshots
<!-- screenshots-start -->
### header

| | Before | After |
|---|---|---|
| Light | ![before light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr39-before-header-light.png) | ![after light](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr39-after-header-light.png) |
| Dark | ![before dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr39-before-header-dark.png) | ![after dark](https://github.com/owenw2k/travel-buddy/releases/download/screenshots-cdn/pr39-after-header-dark.png) |
<!-- screenshots-end -->